### PR TITLE
State propagation distributions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["edition2021"]
-
 [package]
 name = "newregex"
 version = "0.1.0"

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -29,7 +29,11 @@ impl fmt::Display for Kind {
             Kind::Literal(c) => write!(f, "{}", c),
             Kind::Concatenation(l, r) => write!(f, "{}{}.", l, r),
             Kind::Quantified(r, l, Some(q)) => write!(f, "{}{{{}{}}}", l, r, q),
-            Kind::Quantified(r, l, None) => write!(f, "{}{{{}}}", l, r),
+            Kind::Quantified(r, l, None) => match r.kind {
+                Kind::Quantifier(_) => write!(f, "{}{}", l, r),
+                Kind::ExactQuantifier(_) => write!(f, "{}{{{}}}", l, r),
+                _ => unreachable!(),
+            },
             Kind::Quantifier(c) => write!(f, "{}", c),
             Kind::ExactQuantifier(n) => write!(f, "{}", n),
             Kind::Alternation(l, r) => write!(f, "{}|{}", l, r),
@@ -81,7 +85,7 @@ pub fn build_ast_from_expr(pair: pest::iterators::Pair<Rule>) -> AstNode {
             // pair.next is Option<QuantifierDist>
             let quantifier_dist = match pair.next() {
                 Some(pair) => Some(Dist::from(pair)),
-                None => Some(Dist::default_from(&quantifier_ast.kind)),
+                None => Dist::default_from(&quantifier_ast.kind),
             };
             AstNode {
                 length: left_ast.length + quantifier_ast.length,

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -82,9 +82,9 @@ pub fn build_ast_from_expr(pair: pest::iterators::Pair<Rule>) -> AstNode {
             let left_ast = build_ast_from_expr(pair.next().unwrap());
             // pair.next is ShortQuantifier or LongQuantifier
             let quantifier_ast = build_ast_from_expr(pair.next().unwrap());
-            // pair.next is Option<QuantifierDist>
+            // pair.next is Option<Dist>
             let quantifier_dist = match pair.next() {
-                Some(pair) => Some(Dist::from(pair)),
+                Some(pair) => Some(Dist::complete_from(&quantifier_ast.kind, pair)),
                 None => Dist::default_from(&quantifier_ast.kind),
             };
             AstNode {

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -80,6 +80,8 @@ pub fn build_ast_from_expr(pair: pest::iterators::Pair<Rule>) -> AstNode {
             let quantifier_ast = build_ast_from_expr(pair.next().unwrap());
             // pair.next is Option<QuantifierDist>
             let quantifier_dist = match pair.next() {
+                Some(pair) => Some(Dist::from(pair)),
+                None => Some(Dist::default_from(&quantifier_ast.kind)),
             };
             AstNode {
                 length: left_ast.length + quantifier_ast.length,

--- a/src/distribution.rs
+++ b/src/distribution.rs
@@ -24,7 +24,7 @@ impl fmt::Display for Dist {
     }
 }
 
-pub type StateParams = (Dist, f64, u64); // (c, p, visits)
+pub type StateParams = (Dist, f64, u64); // (distribution, p, visits)
 
 pub fn evaluate(p0: f64, params: Option<&StateParams>) -> (f64, f64) {
     if let Some((dist, _, n)) = params {

--- a/src/distribution.rs
+++ b/src/distribution.rs
@@ -5,12 +5,23 @@ use itertools::Itertools;
 use statrs::distribution::{Discrete, Geometric};
 use statrs::statistics::Distribution;
 use std::collections::{HashMap, HashSet};
+use std::fmt;
 
-#[derive(Debug, PartialEq, PartialOrd)]
+#[derive(Debug, PartialEq, PartialOrd, Clone)]
 pub enum Dist {
     Constant(f64),
     ExactlyTimes(u64),
     PGeometric(f64),
+}
+
+impl fmt::Display for Dist {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Dist::Constant(_) => write!(f, ""),
+            Dist::ExactlyTimes(n) => write!(f, "{{{}}}", n),
+            Dist::PGeometric(p) => write!(f, "{{~G({}))}}", p),
+        }
+    }
 }
 
 pub type StateParams = (Dist, f64, u64); // (c, p, visits)

--- a/src/distribution.rs
+++ b/src/distribution.rs
@@ -18,8 +18,8 @@ impl fmt::Display for Dist {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Dist::Constant(_) => write!(f, ""),
-            Dist::ExactlyTimes(n) => write!(f, "{{{}}}", n),
-            Dist::PGeometric(p) => write!(f, "{{~G({}))}}", p),
+            Dist::ExactlyTimes(n) => write!(f, ""),
+            Dist::PGeometric(p) => write!(f, "~Geo({})", p),
         }
     }
 }

--- a/src/distribution.rs
+++ b/src/distribution.rs
@@ -10,9 +10,9 @@ use std::fmt;
 
 #[derive(Debug, PartialEq, PartialOrd, Clone)]
 pub enum Dist {
-    Constant(f64),
-    ExactlyTimes(u64),
-    PGeometric(f64),
+    Constant(f64),        // p
+    ExactlyTimes(u64),    // n_min
+    PGeometric(u64, f64), // n_min, p
 }
 
 impl fmt::Display for Dist {
@@ -20,19 +20,38 @@ impl fmt::Display for Dist {
         match self {
             Dist::Constant(_) => write!(f, ""),
             Dist::ExactlyTimes(n) => write!(f, ""),
-            Dist::PGeometric(p) => write!(f, "~Geo({})", p),
+            Dist::PGeometric(_, p) => write!(f, "~Geo({})", p),
         }
     }
 }
 
-impl From<pest::iterators::Pair<'_, crate::parser::Rule>> for Dist {
-    fn from(quantifier_dist_pair: pest::iterators::Pair<'_, crate::parser::Rule>) -> Self {
+impl Dist {
+    pub fn default_from(quantifier_kind: &Kind) -> Option<Self> {
+        match quantifier_kind {
+            Kind::ExactQuantifier(n) => Some(Dist::ExactlyTimes(*n)),
+            _ => None,
+        }
+    }
+
+    /// Distribution from quantifier kind and distribution params
+    ///
+    /// Eg. complete_from(ExactQuantifier(2), Dist::Normal(sigma))
+    /// would return a Normal distribution centered at 2.
+    pub fn complete_from(
+        quantifier_kind: &Kind,
+        quantifier_dist_pair: pest::iterators::Pair<'_, crate::parser::Rule>,
+    ) -> Self {
+        let n_min = match quantifier_kind {
+            Kind::ExactQuantifier(n) => *n,
+            _ => 1, // TODO what to do here
+        };
+
         let (name, param) = quantifier_dist_pair.into_inner().collect_tuple().unwrap();
         let name = name.as_span().as_str().to_lowercase();
         match name.as_str() {
             "geo" => {
                 let p: f64 = param.as_str().parse().unwrap();
-                Dist::PGeometric(p)
+                Dist::PGeometric(n_min, p)
             }
             _ => {
                 panic!("Unknown distribution {}", name)
@@ -67,11 +86,12 @@ pub fn evaluate(p0: f64, params: &StateParams) -> (f64, f64) {
                     (0.0, 0.0)
                 }
             }
-            Dist::PGeometric(c) => {
-                if *n == 0 {
+            Dist::PGeometric(match_n, c) => {
+                if *n < *match_n {
                     return (p0, 0.0);
                 }
-                let p = Geometric::new(*c).unwrap().pmf(*n);
+                let x = *n - *match_n + 1;
+                let p = Geometric::new(*c).unwrap().pmf(x);
                 (p * p0, (1.0 - p) * p0)
             }
         };
@@ -136,31 +156,60 @@ mod test {
     }
 
     #[test]
-    fn test_distribution_geometric() {
+    fn test_distribution_geometric_1_or_more() {
         assert_eq!(
-            evaluate(1.0, &(Some(Dist::PGeometric(0.5)), 0.0, 0)),
+            evaluate(1.0, &(Some(Dist::PGeometric(1, 0.5)), 0.0, 0)),
             (1.0, 0.0)
         );
         assert_eq!(
-            evaluate(1.0, &(Some(Dist::PGeometric(0.5)), 0.0, 1)),
+            evaluate(1.0, &(Some(Dist::PGeometric(1, 0.5)), 0.0, 1)),
             (0.5, 0.5)
         );
         assert_eq!(
-            evaluate(1.0, &(Some(Dist::PGeometric(0.5)), 0.0, 2)),
+            evaluate(1.0, &(Some(Dist::PGeometric(1, 0.5)), 0.0, 2)),
             (0.25, 0.75)
         );
 
         assert_eq!(
-            evaluate(0.5, &(Some(Dist::PGeometric(0.5)), 0.0, 0)),
+            evaluate(0.5, &(Some(Dist::PGeometric(1, 0.5)), 0.0, 0)),
             (0.5, 0.0)
         );
         assert_eq!(
-            evaluate(0.5, &(Some(Dist::PGeometric(0.5)), 0.0, 1)),
+            evaluate(0.5, &(Some(Dist::PGeometric(1, 0.5)), 0.0, 1)),
             (0.25, 0.25)
         );
         assert_eq!(
-            evaluate(0.5, &(Some(Dist::PGeometric(0.5)), 0.0, 2)),
+            evaluate(0.5, &(Some(Dist::PGeometric(1, 0.5)), 0.0, 2)),
             (0.125, 0.375)
+        );
+    }
+
+    #[test]
+    fn test_distribution_geometric_2_or_more() {
+        assert_eq!(
+            evaluate(1.0, &(Some(Dist::PGeometric(2, 0.5)), 0.0, 0)),
+            (1.0, 0.0)
+        );
+        assert_eq!(
+            evaluate(1.0, &(Some(Dist::PGeometric(2, 0.5)), 0.0, 1)),
+            (1.0, 0.0)
+        );
+        assert_eq!(
+            evaluate(1.0, &(Some(Dist::PGeometric(2, 0.5)), 0.0, 2)),
+            (0.5, 0.5)
+        );
+
+        assert_eq!(
+            evaluate(0.5, &(Some(Dist::PGeometric(2, 0.5)), 0.0, 0)),
+            (0.5, 0.0)
+        );
+        assert_eq!(
+            evaluate(0.5, &(Some(Dist::PGeometric(2, 0.5)), 0.0, 1)),
+            (0.5, 0.0)
+        );
+        assert_eq!(
+            evaluate(0.5, &(Some(Dist::PGeometric(2, 0.5)), 0.0, 2)),
+            (0.25, 0.25)
         );
     }
 }

--- a/src/distribution.rs
+++ b/src/distribution.rs
@@ -42,16 +42,18 @@ impl From<pest::iterators::Pair<'_, crate::parser::Rule>> for Dist {
 }
 
 impl Dist {
-    pub fn default_from(quantifier_kind: &Kind) -> Dist {
+    pub fn default_from(quantifier_kind: &Kind) -> Option<Dist> {
         match quantifier_kind {
-            Kind::ExactQuantifier(n) => Dist::ExactlyTimes(*n),
-            _ => Dist::Constant(1.0),
+            Kind::ExactQuantifier(n) => Some(Dist::ExactlyTimes(*n)),
+            _ => None,
         }
     }
 }
 
 pub type StateParams = (Dist, f64, u64); // (distribution, p, visits)
 
+/// Evaluate p for state arrows (state.outs) from base p (p0) and
+/// state's distribution parameters.
 pub fn evaluate(p0: f64, params: Option<&StateParams>) -> (f64, f64) {
     if let Some((dist, _, n)) = params {
         return match dist {

--- a/src/distribution.rs
+++ b/src/distribution.rs
@@ -50,12 +50,12 @@ impl Dist {
     }
 }
 
-pub type StateParams = (Dist, f64, u64); // (distribution, p, visits)
+pub type StateParams = (Option<Dist>, f64, u64); // (distribution, p, visits)
 
 /// Evaluate p for state arrows (state.outs) from base p (p0) and
 /// state's distribution parameters.
-pub fn evaluate(p0: f64, params: Option<&StateParams>) -> (f64, f64) {
-    if let Some((dist, _, n)) = params {
+pub fn evaluate(p0: f64, params: &StateParams) -> (f64, f64) {
+    if let (Some(dist), _, n) = params {
         return match dist {
             Dist::Constant(p) => (p0 * p, p0 * p),
             Dist::ExactlyTimes(match_n) => {
@@ -85,15 +85,15 @@ mod test {
     #[test]
     fn test_distribution_constant() {
         assert_eq!(
-            evaluate(1.0, Some(&(Dist::Constant(1.0), 0.0, 1))),
+            evaluate(1.0, &(Some(Dist::Constant(1.0)), 0.0, 1)),
             (1.0, 1.0)
         );
         assert_eq!(
-            evaluate(0.5, Some(&(Dist::Constant(1.0), 0.0, 1))),
+            evaluate(0.5, &(Some(Dist::Constant(1.0)), 0.0, 1)),
             (0.5, 0.5)
         );
         assert_eq!(
-            evaluate(1.0, Some(&(Dist::Constant(0.5), 0.0, 1))),
+            evaluate(1.0, &(Some(Dist::Constant(0.5)), 0.0, 1)),
             (0.5, 0.5)
         );
     }
@@ -101,36 +101,36 @@ mod test {
     #[test]
     fn test_distribution_exactly_times() {
         assert_eq!(
-            evaluate(1.0, Some(&(Dist::ExactlyTimes(2), 0.0, 0))),
+            evaluate(1.0, &(Some(Dist::ExactlyTimes(2)), 0.0, 0)),
             (1.0, 0.0)
         );
         assert_eq!(
-            evaluate(1.0, Some(&(Dist::ExactlyTimes(2), 0.0, 1))),
+            evaluate(1.0, &(Some(Dist::ExactlyTimes(2)), 0.0, 1)),
             (1.0, 0.0)
         );
         assert_eq!(
-            evaluate(1.0, Some(&(Dist::ExactlyTimes(2), 0.0, 2))),
+            evaluate(1.0, &(Some(Dist::ExactlyTimes(2)), 0.0, 2)),
             (0.0, 1.0)
         );
         assert_eq!(
-            evaluate(1.0, Some(&(Dist::ExactlyTimes(2), 0.0, 3))),
+            evaluate(1.0, &(Some(Dist::ExactlyTimes(2)), 0.0, 3)),
             (0.0, 0.0)
         );
 
         assert_eq!(
-            evaluate(0.5, Some(&(Dist::ExactlyTimes(2), 0.0, 0))),
+            evaluate(0.5, &(Some(Dist::ExactlyTimes(2)), 0.0, 0)),
             (0.5, 0.0)
         );
         assert_eq!(
-            evaluate(0.5, Some(&(Dist::ExactlyTimes(2), 0.0, 1))),
+            evaluate(0.5, &(Some(Dist::ExactlyTimes(2)), 0.0, 1)),
             (0.5, 0.0)
         );
         assert_eq!(
-            evaluate(0.5, Some(&(Dist::ExactlyTimes(2), 0.0, 2))),
+            evaluate(0.5, &(Some(Dist::ExactlyTimes(2)), 0.0, 2)),
             (0.0, 0.5)
         );
         assert_eq!(
-            evaluate(0.5, Some(&(Dist::ExactlyTimes(2), 0.0, 3))),
+            evaluate(0.5, &(Some(Dist::ExactlyTimes(2)), 0.0, 3)),
             (0.0, 0.0)
         );
     }
@@ -138,28 +138,28 @@ mod test {
     #[test]
     fn test_distribution_geometric() {
         assert_eq!(
-            evaluate(1.0, Some(&(Dist::PGeometric(0.5), 0.0, 0))),
+            evaluate(1.0, &(Some(Dist::PGeometric(0.5)), 0.0, 0)),
             (1.0, 0.0)
         );
         assert_eq!(
-            evaluate(1.0, Some(&(Dist::PGeometric(0.5), 0.0, 1))),
+            evaluate(1.0, &(Some(Dist::PGeometric(0.5)), 0.0, 1)),
             (0.5, 0.5)
         );
         assert_eq!(
-            evaluate(1.0, Some(&(Dist::PGeometric(0.5), 0.0, 2))),
+            evaluate(1.0, &(Some(Dist::PGeometric(0.5)), 0.0, 2)),
             (0.25, 0.75)
         );
 
         assert_eq!(
-            evaluate(0.5, Some(&(Dist::PGeometric(0.5), 0.0, 0))),
+            evaluate(0.5, &(Some(Dist::PGeometric(0.5)), 0.0, 0)),
             (0.5, 0.0)
         );
         assert_eq!(
-            evaluate(0.5, Some(&(Dist::PGeometric(0.5), 0.0, 1))),
+            evaluate(0.5, &(Some(Dist::PGeometric(0.5)), 0.0, 1)),
             (0.25, 0.25)
         );
         assert_eq!(
-            evaluate(0.5, Some(&(Dist::PGeometric(0.5), 0.0, 2))),
+            evaluate(0.5, &(Some(Dist::PGeometric(0.5)), 0.0, 2)),
             (0.125, 0.375)
         );
     }

--- a/src/distribution.rs
+++ b/src/distribution.rs
@@ -28,7 +28,7 @@ impl fmt::Display for Dist {
 impl From<pest::iterators::Pair<'_, crate::parser::Rule>> for Dist {
     fn from(quantifier_dist_pair: pest::iterators::Pair<'_, crate::parser::Rule>) -> Self {
         let (name, param) = quantifier_dist_pair.into_inner().collect_tuple().unwrap();
-        let name = name.to_string().to_lowercase();
+        let name = name.as_span().as_str().to_lowercase();
         match name.as_str() {
             "geo" => {
                 let p: f64 = param.as_str().parse().unwrap();

--- a/src/grammar.pest
+++ b/src/grammar.pest
@@ -12,7 +12,14 @@ Token           = _{ Literal }
 Quantified      =  { ( Token | Group ) ~ Quantifier }
 Literal         =  { ASCII_ALPHANUMERIC | " " }
 
-Quantifier      = _{ ShortQuantifier | ExactQuantifier }
+Quantifier      = _{ ShortQuantifier | LongQuantifier }
 ShortQuantifier =  { "+" | "?" | "*" }
-ExactQuantifier =  { "{" ~ QuantifierParam ~ "}" }
+LongQuantifier  = _{ "{" ~ ExactQuantifier ~ QuantifierDist? ~ "}" }
+ExactQuantifier =  { QuantifierParam }
+
 QuantifierParam =  { ASCII_DIGIT* }
+QuantifierDist  =  { "~" ~ DistName ~ "(" ~ DistParam ~ ")" }
+DistName        =  { ^"Geo" }
+DistParam       =  { ASCII_FLOAT }
+
+ASCII_FLOAT     = _{ ASCII_DIGIT+ ~ "." ~ ASCII_DIGIT+ }

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ mod distribution;
 mod nfa;
 mod parser;
 mod runner;
+mod utils;
 mod state;
 use config::{parse_options, PATTERN_OPTION, STRING_OPTION};
 

--- a/src/nfa.rs
+++ b/src/nfa.rs
@@ -99,7 +99,7 @@ fn ast_to_frag(ast: AstNode, index: usize, outs: Outs) -> Frag {
             start: index,
             outs: outs,
         },
-        Kind::Quantified(quantifier, quantified) => {
+        Kind::Quantified(quantifier, quantified, _) => {
             quantifier_to_frag(*quantifier, *quantified, index, outs)
         }
         Kind::Quantifier(_) | Kind::ExactQuantifier(_) => Frag {
@@ -303,6 +303,7 @@ mod test {
                                 length: 1,
                                 kind: Kind::Literal('a'),
                             }),
+                            None,
                         ),
                     }),
                     Box::new(AstNode {
@@ -361,6 +362,7 @@ mod test {
                                 length: 1,
                                 kind: Kind::Literal('b'),
                             }),
+                            None,
                         ),
                     }),
                 ),
@@ -415,6 +417,7 @@ mod test {
                                 length: 1,
                                 kind: Kind::Literal('b'),
                             }),
+                            None,
                         ),
                     }),
                 ),
@@ -469,6 +472,7 @@ mod test {
                                 length: 1,
                                 kind: Kind::Literal('b'),
                             }),
+                            None,
                         ),
                     }),
                 ),
@@ -524,6 +528,7 @@ mod test {
                                 length: 1,
                                 kind: Kind::Literal('b'),
                             }),
+                            None,
                         ),
                     }),
                 ),
@@ -600,6 +605,7 @@ mod test {
                             length: 1,
                             kind: Kind::Literal('b'),
                         }),
+                        None,
                     ),
                 }),
             ),

--- a/src/nfa.rs
+++ b/src/nfa.rs
@@ -1,4 +1,5 @@
 use crate::ast::{AstNode, Kind};
+use crate::distribution::Dist;
 use crate::parser::parse;
 
 #[derive(Debug, PartialEq, Clone)]
@@ -508,7 +509,6 @@ mod test {
 
     #[test]
     fn test_compile_exact_quantifier() {
-        // TODO
         let result = ast_to_nfa(
             AstNode {
                 length: 3,
@@ -528,7 +528,62 @@ mod test {
                                 length: 1,
                                 kind: Kind::Literal('b'),
                             }),
-                            None,
+                            Some(Dist::ExactlyTimes(2)),
+                        ),
+                    }),
+                ),
+            },
+            0,
+            3,
+        );
+        let expected = vec![
+            State::from(
+                AstNode {
+                    length: 1,
+                    kind: Kind::Literal('a'),
+                },
+                (Some(1), None),
+            ),
+            State::from(
+                AstNode {
+                    length: 1,
+                    kind: Kind::Literal('b'),
+                },
+                (Some(2), None),
+            ),
+            State::from(
+                AstNode {
+                    length: 1,
+                    kind: Kind::ExactQuantifier(2),
+                },
+                (Some(1), Some(3)),
+            ),
+        ];
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_compile_exact_quantifier_dist() {
+        let result = ast_to_nfa(
+            AstNode {
+                length: 3,
+                kind: Kind::Concatenation(
+                    Box::new(AstNode {
+                        length: 1,
+                        kind: Kind::Literal('a'),
+                    }),
+                    Box::new(AstNode {
+                        length: 1,
+                        kind: Kind::Quantified(
+                            Box::new(AstNode {
+                                length: 1,
+                                kind: Kind::ExactQuantifier(2),
+                            }),
+                            Box::new(AstNode {
+                                length: 1,
+                                kind: Kind::Literal('b'),
+                            }),
+                            Some(Dist::PGeometric(0.5)),
                         ),
                     }),
                 ),

--- a/src/nfa.rs
+++ b/src/nfa.rs
@@ -6,16 +6,12 @@ use crate::parser::parse;
 pub struct State {
     pub kind: Kind,
     pub outs: Outs,
-    pub params: Option<StateParams>,
+    pub params: Option<Dist>,
 }
 
 impl State {
-    pub fn new(node: AstNode, params: Option<StateParams>) -> State {
-        State {
-            kind: node.kind,
-            outs: (None, None),
-            params,
-        }
+    pub fn new(kind: Kind, outs: Outs, params: Option<Dist>) -> State {
+        State { kind, outs, params }
     }
     pub fn from(node: AstNode, outs: Outs) -> State {
         State {
@@ -124,14 +120,14 @@ fn ast_to_frag(ast: AstNode, index: usize, outs: Outs, distribution: Option<Dist
         Kind::Quantifier(_) | Kind::ExactQuantifier(_) => Frag {
             // quantifier points to outs
             // quantifier as start
-            states: vec![State::from(ast, outs)],
+            states: vec![State::new(ast.kind, outs, distribution)],
             start: index,
             outs: outs,
         },
         Kind::Terminal => Frag {
             // terminal points to none
             // terminal as start
-            states: vec![State::new(ast, None)],
+            states: vec![State::terminal()],
             start: index,
             outs: (None, None),
         },
@@ -587,12 +583,10 @@ mod test {
                 },
                 (Some(2), None),
             ),
-            State::from(
-                AstNode {
-                    length: 1,
-                    kind: Kind::ExactQuantifier(2),
-                },
+            State::new(
+                Kind::ExactQuantifier(2),
                 (Some(1), Some(3)),
+                Some(Dist::ExactlyTimes(2)),
             ),
         ];
         assert_eq!(result, expected);
@@ -642,12 +636,10 @@ mod test {
                 },
                 (Some(2), None),
             ),
-            State::from(
-                AstNode {
-                    length: 1,
-                    kind: Kind::ExactQuantifier(2),
-                },
+            State::new(
+                Kind::ExactQuantifier(2),
                 (Some(1), Some(3)),
+                Some(Dist::PGeometric(0.5)),
             ),
         ];
         assert_eq!(result, expected);
@@ -820,12 +812,10 @@ mod test {
                 },
                 (Some(2), None),
             ),
-            State::from(
-                AstNode {
-                    length: 1,
-                    kind: Kind::ExactQuantifier(2),
-                },
+            State::new(
+                Kind::ExactQuantifier(2),
                 (Some(1), Some(3)),
+                Some(Dist::ExactlyTimes(2)),
             ),
             State::from(
                 AstNode {

--- a/src/nfa.rs
+++ b/src/nfa.rs
@@ -1,11 +1,12 @@
 use crate::ast::{AstNode, Kind};
-use crate::distribution::Dist;
+use crate::distribution::{Dist, StateParams};
 use crate::parser::parse;
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct State {
     pub kind: Kind,
     pub outs: Outs,
+    pub params: Option<StateParams>,
 }
 
 impl State {
@@ -13,12 +14,21 @@ impl State {
         State {
             kind: node.kind,
             outs: (None, None),
+            params: None,
         }
     }
     pub fn from(node: AstNode, outs: Outs) -> State {
         State {
             kind: node.kind,
             outs: outs,
+            params: None,
+        }
+    }
+    pub fn start(idx: usize) -> State {
+        State {
+            kind: Kind::Start,
+            outs: (Some(idx), None),
+            params: None,
         }
     }
 }
@@ -670,10 +680,7 @@ mod test {
             kind: Kind::Terminal,
         };
         let expected = vec![
-            State {
-                kind: Kind::Start,
-                outs: (Some(1), None),
-            },
+            State::start(1),
             State::from(
                 AstNode {
                     length: 1,
@@ -710,10 +717,7 @@ mod test {
         let asts = parse("ab?c").unwrap();
         let result = asts_to_nfa(asts);
         let expected = vec![
-            State {
-                kind: Kind::Start,
-                outs: (Some(1), None),
-            },
+            State::start(1),
             State::from(
                 AstNode {
                     length: 1,
@@ -755,10 +759,7 @@ mod test {
         let asts = parse("a?b").unwrap();
         let result = asts_to_nfa(asts);
         let expected = vec![
-            State {
-                kind: Kind::Start,
-                outs: (Some(2), None),
-            },
+            State::start(2),
             State::from(
                 AstNode {
                     length: 1,
@@ -793,10 +794,7 @@ mod test {
         let asts = parse("a{2}b").unwrap();
         let result = asts_to_nfa(asts);
         let expected = vec![
-            State {
-                kind: Kind::Start,
-                outs: (Some(1), None),
-            },
+            State::start(1),
             State::from(
                 AstNode {
                     length: 1,

--- a/src/nfa.rs
+++ b/src/nfa.rs
@@ -613,7 +613,7 @@ mod test {
                                 length: 1,
                                 kind: Kind::Literal('b'),
                             }),
-                            Some(Dist::PGeometric(0.5)),
+                            Some(Dist::PGeometric(2, 0.5)),
                         ),
                     }),
                 ),
@@ -639,7 +639,7 @@ mod test {
             State::new(
                 Kind::ExactQuantifier(2),
                 (Some(1), Some(3)),
-                Some(Dist::PGeometric(0.5)),
+                Some(Dist::PGeometric(2, 0.5)),
             ),
         ];
         assert_eq!(result, expected);

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -178,7 +178,7 @@ mod test {
                         length: 1,
                         kind: Kind::Literal('a'),
                     }),
-                    Some(Dist::PGeometric(0.5)),
+                    Some(Dist::PGeometric(2, 0.5)),
                 ),
             },
             AstNode {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -90,6 +90,7 @@ mod test {
                         length: 1,
                         kind: Kind::Literal('a'),
                     }),
+                    None,
                 ),
             },
             AstNode {
@@ -118,6 +119,7 @@ mod test {
                                 length: 1,
                                 kind: Kind::Literal('a'),
                             }),
+                            None,
                         ),
                     }),
                     Box::new(AstNode {
@@ -149,6 +151,7 @@ mod test {
                         length: 1,
                         kind: Kind::Literal('a'),
                     }),
+                    None,
                 ),
             },
             AstNode {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -152,7 +152,33 @@ mod test {
                         length: 1,
                         kind: Kind::Literal('a'),
                     }),
-                    None,
+                    Some(Dist::ExactlyTimes(2)),
+                ),
+            },
+            AstNode {
+                length: 0,
+                kind: Kind::Terminal,
+            },
+        ];
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_parser_exact_quantifier_dist_ast() {
+        let result = parse("a{2~Geo(0.5)}").unwrap_or(vec![]);
+        let expected = vec![
+            AstNode {
+                length: 2,
+                kind: Kind::Quantified(
+                    Box::new(AstNode {
+                        length: 1,
+                        kind: Kind::ExactQuantifier(2),
+                    }),
+                    Box::new(AstNode {
+                        length: 1,
+                        kind: Kind::Literal('a'),
+                    }),
+                    Some(Dist::PGeometric(0.5)),
                 ),
             },
             AstNode {
@@ -216,5 +242,10 @@ mod test {
     fn test_parser_exact_quantifier() {
         assert_eq!(ast_as_str(parse("a{2}").unwrap()), "a{2}$");
         assert_eq!(ast_as_str(parse("a{20}").unwrap()), "a{20}$");
+    }
+
+    #[test]
+    fn test_parser_exact_quantifier_dist() {
+        assert_eq!(ast_as_str(parse("a{2~Geo(1.0)}").unwrap()), "a{2~Geo(1)}$");
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -26,6 +26,7 @@ pub fn parse(source: &str) -> std::result::Result<Vec<AstNode>, pest::error::Err
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::distribution::Dist;
 
     fn ast_as_str(asts: Vec<AstNode>) -> String {
         asts.into_iter()

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -286,10 +286,7 @@ mod test {
     #[test]
     fn test_matches_exact_quantifier() {
         let nfa = vec![
-            State {
-                kind: Kind::Start,
-                outs: (Some(1), None),
-            },
+            State::start(1),
             State::from(
                 AstNode {
                     length: 1,

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1,5 +1,6 @@
 #![allow(dead_code, unused_imports, unused_mut, unused_variables)]
 use crate::ast::{AstNode, Kind};
+use crate::distribution::Dist;
 use crate::nfa::State;
 use crate::state::NfaState;
 use log::Level;
@@ -43,13 +44,7 @@ mod test {
                 },
                 (Some(2), None),
             ),
-            State::new(
-                AstNode {
-                    length: 1,
-                    kind: Kind::Terminal,
-                },
-                None,
-            ),
+            State::terminal(),
         ];
         assert_eq!(matches(&nfa, "ab"), true);
         assert_eq!(matches(&nfa, "bb"), false);
@@ -88,13 +83,7 @@ mod test {
                 },
                 (Some(4), None),
             ),
-            State::new(
-                AstNode {
-                    length: 1,
-                    kind: Kind::Terminal,
-                },
-                None,
-            ),
+            State::terminal(),
         ];
         assert_eq!(matches(&nfa, "a"), true);
         assert_eq!(matches(&nfa, "ax"), true);
@@ -288,12 +277,10 @@ mod test {
                 },
                 (Some(2), None),
             ),
-            State::from(
-                AstNode {
-                    length: 1,
-                    kind: Kind::ExactQuantifier(2),
-                },
+            State::new(
+                Kind::ExactQuantifier(2),
                 (Some(1), Some(3)),
+                Some(Dist::ExactlyTimes(2)),
             ),
             State::from(
                 AstNode {

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -43,10 +43,13 @@ mod test {
                 },
                 (Some(2), None),
             ),
-            State::new(AstNode {
-                length: 1,
-                kind: Kind::Terminal,
-            }),
+            State::new(
+                AstNode {
+                    length: 1,
+                    kind: Kind::Terminal,
+                },
+                None,
+            ),
         ];
         assert_eq!(matches(&nfa, "ab"), true);
         assert_eq!(matches(&nfa, "bb"), false);
@@ -85,10 +88,13 @@ mod test {
                 },
                 (Some(4), None),
             ),
-            State::new(AstNode {
-                length: 1,
-                kind: Kind::Terminal,
-            }),
+            State::new(
+                AstNode {
+                    length: 1,
+                    kind: Kind::Terminal,
+                },
+                None,
+            ),
         ];
         assert_eq!(matches(&nfa, "a"), true);
         assert_eq!(matches(&nfa, "ax"), true);
@@ -128,10 +134,7 @@ mod test {
                 },
                 (Some(4), None),
             ),
-            State::new(AstNode {
-                length: 1,
-                kind: Kind::Terminal,
-            }),
+            State::terminal(),
         ];
         assert_eq!(matches(&nfa, "a"), false);
         assert_eq!(matches(&nfa, "b"), true);
@@ -179,10 +182,7 @@ mod test {
                 },
                 (Some(5), None),
             ),
-            State::new(AstNode {
-                length: 1,
-                kind: Kind::Terminal,
-            }),
+            State::terminal(),
         ];
         assert_eq!(matches(&nfa, "a"), false);
         assert_eq!(matches(&nfa, "ab"), false);
@@ -224,10 +224,7 @@ mod test {
                 },
                 (Some(4), None),
             ),
-            State::new(AstNode {
-                length: 1,
-                kind: Kind::Terminal,
-            }),
+            State::terminal(),
         ];
         assert_eq!(matches(&nfa, "a"), false);
         assert_eq!(matches(&nfa, "ab"), false);
@@ -269,10 +266,7 @@ mod test {
                 },
                 (Some(4), None),
             ),
-            State::new(AstNode {
-                length: 1,
-                kind: Kind::Terminal,
-            }),
+            State::terminal(),
         ];
         assert_eq!(matches(&nfa, "a"), false);
         assert_eq!(matches(&nfa, "ab"), false);
@@ -286,7 +280,7 @@ mod test {
     #[test]
     fn test_matches_exact_quantifier() {
         let nfa = vec![
-            State::start(1),
+            State::start(Some(1)),
             State::from(
                 AstNode {
                     length: 1,
@@ -308,10 +302,7 @@ mod test {
                 },
                 (Some(4), None),
             ),
-            State::new(AstNode {
-                length: 0,
-                kind: Kind::Terminal,
-            }),
+            State::terminal(),
         ];
         assert_eq!(matches(&nfa, "a"), false);
         assert_eq!(matches(&nfa, "aa"), false);

--- a/src/state.rs
+++ b/src/state.rs
@@ -36,6 +36,7 @@ impl NfaState<'_> {
             .for_each(|(i, p)| self.update_state(*i, 0.0, true));
     }
 
+    /// Add states to set of possible states. Returns max(p(terminal)).
     pub fn add_states(&mut self, states: &HashMap<usize, f64>, force: bool) -> f64 {
         find_max(
             states
@@ -64,17 +65,18 @@ impl NfaState<'_> {
         let state = &self.nfa[idx];
         match state.kind {
             Kind::ExactQuantifier(n) => {
-                self.state_params
+                self.current_states_params
                     .entry(idx)
                     .or_insert((Dist::ExactlyTimes(n), 0.0, 0))
             }
             _ => self
-                .state_params
+                .current_states_params
                 .entry(idx)
                 .or_insert((Dist::Constant(1.0), 0.0, 0)),
         }
     }
 
+    /// Add state to set of possible states. Returns max(p(terminal)).
     pub fn add_state(&mut self, idx: Option<usize>, force: bool, p: f64) -> f64 {
         let idx = if let Some(idx) = idx { idx } else { return 0.0 };
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -9,7 +9,7 @@ pub struct NfaState<'a> {
     nfa: &'a Vec<State>,
     visited: HashSet<usize>,
     pub current_states: HashSet<usize>,
-    state_params: HashMap<usize, StateParams>,
+    current_states_params: HashMap<usize, StateParams>,
 }
 
 fn find_max<'a, I>(vals: I) -> f64
@@ -24,8 +24,8 @@ impl NfaState<'_> {
         return NfaState {
             nfa: nfa,
             current_states: HashSet::new(),
+            current_states_params: HashMap::new(),
             visited: HashSet::new(),
-            state_params: HashMap::new(),
         };
     }
 
@@ -45,14 +45,14 @@ impl NfaState<'_> {
     }
 
     fn get_count(&self, idx: usize) -> u64 {
-        if let Some(params) = self.state_params.get(&idx) {
+        if let Some(params) = self.current_states_params.get(&idx) {
             return params.2;
         }
         0
     }
 
     fn get_state(&self, idx: usize) -> (f64, &State) {
-        let p = match self.state_params.get(&idx) {
+        let p = match self.current_states_params.get(&idx) {
             Some(params) => params.1,
             None => 0.0,
         };
@@ -148,7 +148,7 @@ impl NfaState<'_> {
         self.update_states_counts(&new_states);
         debug!(
             "  flush {}",
-            self.state_params
+            self.current_states_params
                 .iter()
                 .map(|(k, v)| format!("p({})={}", k, v.1))
                 .join(" ")
@@ -211,7 +211,7 @@ mod test {
         state.init_state(Some(0), true);
         assert_eq!(state.current_states.len(), 1);
         assert_eq!(
-            *state.state_params.get(&1).unwrap(),
+            *state.current_states_params.get(&1).unwrap(),
             (Dist::Constant(1.0), 1.0, 0)
         );
         assert_eq!(state.visited.len(), 0);
@@ -389,19 +389,19 @@ mod test {
         state.init_state(Some(0), true);
         assert_eq!(state.step('a'), 0.0);
         let probs = state
-            .state_params
+            .current_states_params
             .keys()
             .sorted()
-            .map(|k| state.state_params[k].1)
+            .map(|k| state.current_states_params[k].1)
             .collect::<Vec<f64>>();
         assert_eq!(probs, vec![1.0, 0.0, 0.0]);
 
         assert_eq!(state.step('a'), 1.0);
         let probs = state
-            .state_params
+            .current_states_params
             .keys()
             .sorted()
-            .map(|k| state.state_params[k].1)
+            .map(|k| state.current_states_params[k].1)
             .collect::<Vec<f64>>();
         assert_eq!(probs, vec![0.0, 0.0, 1.0]);
     }

--- a/src/state.rs
+++ b/src/state.rs
@@ -382,32 +382,54 @@ mod test {
         let mut state = NfaState::new(&nfa);
         state.init_state(Some(0), true);
         assert_eq!(state.step('a'), 0.0);
-        assert_eq!(utils::probs(&state.current_states_params), vec![1.0, 0.0, 0.0]);
+        assert_eq!(
+            utils::probs(&state.current_states_params),
+            vec![1.0, 0.0, 0.0]
+        );
 
         assert_eq!(state.step('a'), 1.0);
-        assert_eq!(utils::probs(&state.current_states_params), vec![0.0, 0.0, 1.0]);
+        assert_eq!(
+            utils::probs(&state.current_states_params),
+            vec![0.0, 0.0, 1.0]
+        );
     }
 
+    #[test]
+    fn test_state_p_geo_quantifier() {
+        let nfa = vec![
             State::from(
                 AstNode {
                     length: 1,
                     kind: Kind::Literal('a'),
                 },
-                (Some(2), None),
+                (Some(1), None),
             ),
             State::new(
                 Kind::ExactQuantifier(2),
-                (Some(1), Some(2)),
-                Some(Dist::PGeometric(1.0)), // TODO with also 0.5
+                (Some(0), Some(2)),
+                Some(Dist::PGeometric(2, 0.5)),
             ),
             State::terminal(),
         ];
         let mut state = NfaState::new(&nfa);
         state.init_state(Some(0), true);
         assert_eq!(state.step('a'), 0.0);
-        assert_eq!(utils::probs(&state.current_states_params), vec![0.0, 1.0, 0.0]);
 
-        assert_eq!(state.step('a'), 0.0);
-        assert_eq!(utils::probs(&state.current_states_params), vec![0.0, 0.125, 0.25]);
+        assert_eq!(
+            utils::probs(&state.current_states_params),
+            vec![1.0, 0.0, 0.0]
+        );
+
+        assert_eq!(state.step('a'), 0.5);
+        assert_eq!(
+            utils::probs(&state.current_states_params),
+            vec![0.5, 0.0, 0.5]
+        );
+
+        assert_eq!(state.step('a'), 0.5);
+        assert_eq!(
+            utils::probs(&state.current_states_params),
+            vec![0.125, 0.0, 0.375]
+        );
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -361,7 +361,7 @@ mod test {
     }
 
     #[test]
-    fn test_state_probs() {
+    fn test_state_p_exact_quantifier() {
         let nfa = vec![
             State::from(
                 AstNode {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,11 @@
+use itertools::Itertools;
+use crate::distribution::StateParams;
+use std::collections::HashMap;
+
+pub fn probs(params: &HashMap<usize, StateParams>) -> Vec<f64> {
+    params 
+    .keys()
+    .sorted()
+    .map(|k| params[k].1)
+    .collect::<Vec<f64>>()
+}


### PR DESCRIPTION
Propagate distributions more sensibly and fix distribution offset issue (quantified has to be a param to distribution creation, eg. when doing a normal distribution 2~Normal).

This now works (somewhat):
```
cargo run -- "a{2~Geo(0.5)}b" aaab
```

Calculations:
* Fix `PGeometric` to "stay" (i.e. return (1,0)) until `n_min` is exceeded.
* Add distribution to quantifier `Quantified(quantifier, quantified)` -> `Quantified(quantifier,quantified,distribution)` (note: exact quantifier is now a special case?)

Parsing:
* Add quantifier distribution to pest grammar
* Add `distribution` param to `quantifier_to_frag`

Misc:
* Add `State::start()` and `State::terminal()` helpers.
* Improve debug logging
