### PR TITLE
Anchors

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -71,7 +71,7 @@ pub fn build_ast_from_expr(pair: pest::iterators::Pair<Rule>) -> AstNode {
         }
         Rule::AnchorStart => {
             return AstNode {
-                length: 1,
+                length: 0,
                 kind: Kind::AnchorStart,
             };
         }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -21,6 +21,7 @@ pub enum Kind {
     Split,
     Terminal,
     Start,
+    AnchorStart,
 }
 
 impl fmt::Display for Kind {
@@ -39,7 +40,8 @@ impl fmt::Display for Kind {
             Kind::Alternation(l, r) => write!(f, "{}|{}", l, r),
             Kind::Split => write!(f, "|"),
             Kind::Terminal => write!(f, "$"),
-            Kind::Start => write!(f, "^"),
+            Kind::Start => write!(f, ""),
+            Kind::AnchorStart => write!(f, "^"),
             // See also fmt::Display for Dist
         }
     }
@@ -66,6 +68,12 @@ pub fn build_ast_from_expr(pair: pest::iterators::Pair<Rule>) -> AstNode {
                 };
             }
             left_ast
+        }
+        Rule::AnchorStart => {
+            return AstNode {
+                length: 1,
+                kind: Kind::AnchorStart,
+            };
         }
         Rule::Concat | Rule::Concats => {
             let mut pair = pair.into_inner();

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -75,7 +75,7 @@ pub fn build_ast_from_expr(pair: pest::iterators::Pair<Rule>) -> AstNode {
         }
         Rule::AnchorEnd => {
             return AstNode {
-                length: 0,
+                length: 1,
                 kind: Kind::AnchorEnd,
             };
         }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -8,9 +8,7 @@ use std::fmt;
 pub struct AstNode {
     pub length: usize,
     pub kind: Kind,
-    // Keep distirbution out of here
 }
-// TODO create a helper ::new function to cut boilerplate
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum Kind {

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -8,20 +8,23 @@ use std::fmt;
 pub struct AstNode {
     pub length: usize,
     pub kind: Kind,
+    // Keep distirbution out of here
 }
+// TODO create a helper ::new function to cut boilerplate
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum Kind {
+    AnchorEnd,
+    AnchorStart,
+    Alternation(Box<AstNode>, Box<AstNode>),
+    Concatenation(Box<AstNode>, Box<AstNode>),
+    ExactQuantifier(u64),
     Literal(char),
+    Split,
+    Start,
+    Terminal,
     Quantified(Box<AstNode>, Box<AstNode>, Option<Dist>),
     Quantifier(char),
-    ExactQuantifier(u64),
-    Concatenation(Box<AstNode>, Box<AstNode>),
-    Alternation(Box<AstNode>, Box<AstNode>),
-    Split,
-    Terminal,
-    Start,
-    AnchorStart,
 }
 
 impl fmt::Display for Kind {
@@ -39,9 +42,10 @@ impl fmt::Display for Kind {
             Kind::ExactQuantifier(n) => write!(f, "{}", n),
             Kind::Alternation(l, r) => write!(f, "{}|{}", l, r),
             Kind::Split => write!(f, "|"),
-            Kind::Terminal => write!(f, "$"),
+            Kind::Terminal => write!(f, ""),
             Kind::Start => write!(f, ""),
             Kind::AnchorStart => write!(f, "^"),
+            Kind::AnchorEnd => write!(f, "$"),
             // See also fmt::Display for Dist
         }
     }
@@ -68,6 +72,12 @@ pub fn build_ast_from_expr(pair: pest::iterators::Pair<Rule>) -> AstNode {
                 };
             }
             left_ast
+        }
+        Rule::AnchorEnd => {
+            return AstNode {
+                length: 0,
+                kind: Kind::AnchorEnd,
+            };
         }
         Rule::AnchorStart => {
             return AstNode {

--- a/src/distribution.rs
+++ b/src/distribution.rs
@@ -109,7 +109,7 @@ impl Dist {
             }
             Dist::PBinomial(n_max, p) => {
                 if n > *n_max {
-                    return (p0, 0.0);
+                    return (0.0, 0.0);
                 }
                 let x = n;
                 match log {
@@ -196,17 +196,21 @@ mod test {
     }
     #[test]
     fn test_distribution_binomial_degenerate() {
-        // If p = 1 the distribution is concentrated at n
+        // p = 1, the distribution is concentrated at 0
         assert_eq!(Dist::PBinomial(0, 1.0).evaluate(1.0, 0, false), (0.0, 1.0));
-        assert_eq!(Dist::PBinomial(0, 1.0).evaluate(1.0, 1, false), (1.0, 0.0));
+        assert_eq!(Dist::PBinomial(0, 1.0).evaluate(1.0, 1, false), (0.0, 0.0));
+        assert_eq!(Dist::PBinomial(0, 1.0).evaluate(1.0, 2, false), (0.0, 0.0));
+
+        // p = 1, the distribution is concentrated at 1
         assert_eq!(Dist::PBinomial(1, 1.0).evaluate(1.0, 1, false), (0.0, 1.0));
+        assert_eq!(Dist::PBinomial(1, 1.0).evaluate(1.0, 2, false), (0.0, 0.0));
     }
 
     #[test]
     fn test_distribution_binomial_up_to_1() {
         assert_eq!(Dist::PBinomial(1, 0.5).evaluate(1.0, 0, false), (0.5, 0.5));
         assert_eq!(Dist::PBinomial(1, 0.5).evaluate(1.0, 1, false), (0.5, 0.5));
-        assert_eq!(Dist::PBinomial(1, 0.5).evaluate(1.0, 2, false), (1.0, 0.0));
+        assert_eq!(Dist::PBinomial(1, 0.5).evaluate(1.0, 2, false), (0.0, 0.0));
     }
 
     #[test]
@@ -220,7 +224,7 @@ mod test {
             Dist::PBinomial(2, 0.5).evaluate(1.0, 2, false),
             (0.75, 0.25)
         );
-        assert_eq!(Dist::PBinomial(2, 0.5).evaluate(1.0, 3, false), (1.0, 0.0));
+        assert_eq!(Dist::PBinomial(2, 0.5).evaluate(1.0, 3, false), (0.0, 0.0));
     }
 
     #[test]

--- a/src/distribution.rs
+++ b/src/distribution.rs
@@ -215,16 +215,11 @@ mod test {
 
     #[test]
     fn test_distribution_binomial_up_to_2() {
-        assert_eq!(
-            Dist::PBinomial(2, 0.5).evaluate(1.0, 0, false),
-            (0.75, 0.25)
-        );
-        assert_eq!(Dist::PBinomial(2, 0.5).evaluate(1.0, 1, false), (0.5, 0.5));
-        assert_eq!(
-            Dist::PBinomial(2, 0.5).evaluate(1.0, 2, false),
-            (0.75, 0.25)
-        );
-        assert_eq!(Dist::PBinomial(2, 0.5).evaluate(1.0, 3, false), (0.0, 0.0));
+        use Dist::PBinomial;
+        assert_eq!(PBinomial(2, 0.5).evaluate(1.0, 0, false), (0.75, 0.25));
+        assert_eq!(PBinomial(2, 0.5).evaluate(1.0, 1, false), (0.5, 0.5));
+        assert_eq!(PBinomial(2, 0.5).evaluate(1.0, 2, false), (0.75, 0.25));
+        assert_eq!(PBinomial(2, 0.5).evaluate(1.0, 3, false), (0.0, 0.0));
     }
 
     #[test]

--- a/src/grammar.pest
+++ b/src/grammar.pest
@@ -1,6 +1,7 @@
 
-Regex           = _{ SOI ~ AnchorStart? ~ ( Alternation | Expression ) ~ EOI }
+Regex           = _{ SOI ~ AnchorStart? ~ ( Alternation | Expression ) ~ AnchorEnd? ~ EOI }
 AnchorStart     =  { "^" }
+AnchorEnd       =  { "$" }
 Alternation     =  { Expression ~ ( "|" ~ ( Alternation | Expression ) ) }
 Expression      = _{ Concats | Concat | Factor }
 

--- a/src/grammar.pest
+++ b/src/grammar.pest
@@ -1,5 +1,6 @@
 
-Regex 			= _{ SOI ~ ( Alternation | Expression ) ~ EOI }
+Regex           = _{ SOI ~ AnchorStart? ~ ( Alternation | Expression ) ~ EOI }
+AnchorStart     =  { "^" }
 Alternation     =  { Expression ~ ( "|" ~ ( Alternation | Expression ) ) }
 Expression      = _{ Concats | Concat | Factor }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,7 +45,7 @@ fn main() -> Result<()> {
                 exit(1);
             }
             Ok(input_string) => match runner::match_p(&nfa, &input_string) {
-                Some(p) => println!("{}\t{}", p, input_string),
+                Some(p) => println!("{:.5}\t{}", p, input_string),
                 None => {}
             },
         }

--- a/src/nfa.rs
+++ b/src/nfa.rs
@@ -39,6 +39,14 @@ impl State {
             dist: None,
         }
     }
+    #[allow(dead_code)]
+    pub fn anchor_start(start: Option<usize>) -> State {
+        State {
+            kind: Kind::AnchorStart,
+            outs: (start, None),
+            dist: None,
+        }
+    }
     pub fn terminal() -> State {
         State {
             kind: Kind::Terminal,
@@ -62,6 +70,7 @@ struct Frag {
 /// The compilation first parses the AST(s) into fragments which
 /// represent partial NFA states following Thompson [1968].
 /// The fragments are then joined to form the final NFA.
+/// The NFA is initialized with a Start state.
 pub fn asts_to_nfa(asts: Vec<AstNode>) -> Vec<State> {
     // concatenate asts to single state list (HACK)
     let mut states = Vec::new();
@@ -69,15 +78,25 @@ pub fn asts_to_nfa(asts: Vec<AstNode>) -> Vec<State> {
     let mut start: Option<usize> = None;
 
     for ast in asts {
+        // Use index as offset for new NFA fragment
         let end = index + ast.length;
         let nfa_frag = ast_to_frag(ast, index, (Some(end), None), None);
         index = nfa_frag.states.len();
-        if let None = start {
+        if start.is_none() {
             start = Some(nfa_frag.start);
         }
         states.extend(nfa_frag.states);
     }
-    let start_state = vec![State::start(start)];
+
+    // Add start state if NFA does not start with one
+    let start_state = match states
+        .get(0)
+        .map(|state| [Kind::Start, Kind::AnchorStart].contains(&state.kind))
+        .unwrap_or(false)
+    {
+        true => vec![],
+        false => vec![State::start(start)],
+    };
     [start_state, states].concat()
 }
 
@@ -108,6 +127,11 @@ fn ast_to_frag(ast: AstNode, index: usize, outs: Outs, distribution: Option<Dist
                 outs: outs,
             }
         }
+        Kind::AnchorStart => Frag {
+            states: vec![State::new(Kind::AnchorStart, outs, None)],
+            start: index,
+            outs,
+        },
         Kind::Concatenation(left, right) => {
             // left points to start of right and right points to outs
             // left as start
@@ -682,7 +706,7 @@ mod test {
     }
 
     #[test]
-    fn test_nfas_to_ast() {
+    fn test_asts_to_nfa() {
         let first = AstNode {
             length: 3,
             kind: Kind::Concatenation(
@@ -741,7 +765,48 @@ mod test {
     }
 
     #[test]
-    fn test_nfas_to_ast2() {
+    fn test_asts_to_nfa_with_anchor_start() {
+        let first = AstNode {
+            length: 1,
+            kind: Kind::AnchorStart,
+        };
+        let second = AstNode {
+            length: 2,
+            kind: Kind::Concatenation(
+                Box::new(AstNode {
+                    length: 1,
+                    kind: Kind::Literal('a'),
+                }),
+                Box::new(AstNode {
+                    length: 1,
+                    kind: Kind::Literal('b'),
+                }),
+            ),
+        };
+        let expected = vec![
+            State::anchor_start(Some(1)),
+            State::from(
+                AstNode {
+                    length: 1,
+                    kind: Kind::Literal('a'),
+                },
+                (Some(2), None),
+            ),
+            State::from(
+                AstNode {
+                    length: 1,
+                    kind: Kind::Literal('b'),
+                },
+                (Some(3), None),
+            ),
+        ];
+
+        let result = asts_to_nfa(vec![first, second]);
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_nfas_to_ast_start_node_special_case_1() {
         let asts = parse("ab?c").unwrap();
         let result = asts_to_nfa(asts);
         let expected = vec![
@@ -780,7 +845,7 @@ mod test {
     }
 
     #[test]
-    fn test_nfas_to_ast3() {
+    fn test_nfas_to_ast_start_node_special_case_2() {
         let asts = parse("a?b").unwrap();
         let result = asts_to_nfa(asts);
         let expected = vec![
@@ -812,7 +877,7 @@ mod test {
     }
 
     #[test]
-    fn test_nfas_to_ast4() {
+    fn test_nfas_to_ast_start_node_special_case_3() {
         let asts = parse("a{2}b").unwrap();
         let result = asts_to_nfa(asts);
         let expected = vec![
@@ -835,6 +900,37 @@ mod test {
                     kind: Kind::Literal('b'),
                 },
                 (Some(4), None),
+            ),
+            State::terminal(),
+        ];
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_nfas_to_ast_with_start_anchor() {
+        let asts = parse("^ab").unwrap();
+        let result = asts_to_nfa(asts);
+        let expected = vec![
+            State::from(
+                AstNode {
+                    length: 0,
+                    kind: Kind::AnchorStart,
+                },
+                (Some(1), None),
+            ),
+            State::from(
+                AstNode {
+                    length: 1,
+                    kind: Kind::Literal('a'),
+                },
+                (Some(2), None),
+            ),
+            State::from(
+                AstNode {
+                    length: 1,
+                    kind: Kind::Literal('b'),
+                },
+                (Some(3), None),
             ),
             State::terminal(),
         ];

--- a/src/nfa.rs
+++ b/src/nfa.rs
@@ -47,6 +47,14 @@ impl State {
             dist: None,
         }
     }
+    #[allow(dead_code)]
+    pub fn anchor_end(end: Option<usize>) -> State {
+        State {
+            kind: Kind::AnchorEnd,
+            outs: (end, None),
+            dist: None,
+        }
+    }
     pub fn terminal() -> State {
         State {
             kind: Kind::Terminal,
@@ -127,7 +135,7 @@ fn ast_to_frag(ast: AstNode, index: usize, outs: Outs, distribution: Option<Dist
                 outs: outs,
             }
         }
-        Kind::AnchorEnd=> Frag {
+        Kind::AnchorEnd => Frag {
             states: vec![State::new(Kind::AnchorEnd, outs, None)],
             start: index,
             outs,
@@ -170,7 +178,7 @@ fn ast_to_frag(ast: AstNode, index: usize, outs: Outs, distribution: Option<Dist
             // start as start
             states: vec![State::new(Kind::Start, outs, None)],
             start: index,
-            outs
+            outs,
         },
         Kind::Terminal => Frag {
             // terminal points to none
@@ -811,6 +819,48 @@ mod test {
                 },
                 (Some(3), None),
             ),
+        ];
+
+        let result = asts_to_nfa(vec![first, second]);
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_asts_to_nfa_with_anchor_end() {
+        let first = AstNode {
+            length: 2,
+            kind: Kind::Concatenation(
+                Box::new(AstNode {
+                    length: 1,
+                    kind: Kind::Literal('a'),
+                }),
+                Box::new(AstNode {
+                    length: 1,
+                    kind: Kind::Literal('b'),
+                }),
+            ),
+        };
+        let second = AstNode {
+            length: 1,
+            kind: Kind::AnchorEnd,
+        };
+        let expected = vec![
+            State::start(Some(1)),
+            State::from(
+                AstNode {
+                    length: 1,
+                    kind: Kind::Literal('a'),
+                },
+                (Some(2), None),
+            ),
+            State::from(
+                AstNode {
+                    length: 1,
+                    kind: Kind::Literal('b'),
+                },
+                (Some(3), None),
+            ),
+            State::anchor_end(Some(4)),
         ];
 
         let result = asts_to_nfa(vec![first, second]);

--- a/src/nfa.rs
+++ b/src/nfa.rs
@@ -765,9 +765,9 @@ mod test {
     }
 
     #[test]
-    fn test_asts_to_nfa_with_anchor_start() {
+    fn test_asts_to_nfa_with_start_anchor() {
         let first = AstNode {
-            length: 1,
+            length: 0,
             kind: Kind::AnchorStart,
         };
         let second = AstNode {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -190,6 +190,26 @@ mod test {
     }
 
     #[test]
+    fn test_parser_anchor_start_ast() {
+        let result = parse("^a").unwrap_or(vec![]);
+        let expected = vec![
+            AstNode {
+                length: 0,
+                kind: Kind::AnchorStart,
+            },
+            AstNode {
+                length: 1,
+                kind: Kind::Literal('a'),
+            },
+            AstNode {
+                length: 0,
+                kind: Kind::Terminal,
+            },
+        ];
+        assert_eq!(result, expected);
+    }
+
+    #[test]
     fn test_parser_concat_length() {
         let result = parse("ab").unwrap_or(vec![]).first().unwrap().to_owned();
         assert_eq!(result.length, 2);

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -217,55 +217,55 @@ mod test {
 
     #[test]
     fn test_parser_alternation() {
-        assert_eq!(ast_as_str(parse("a|b").unwrap()), "a|b$");
-        assert_eq!(ast_as_str(parse("a|b|c").unwrap()), "a|b|c$");
+        assert_eq!(ast_as_str(parse("a|b").unwrap()), "a|b");
+        assert_eq!(ast_as_str(parse("a|b|c").unwrap()), "a|b|c");
     }
 
     #[test]
     fn test_parser_concat() {
-        assert_eq!(ast_as_str(parse("abc").unwrap()), "ab.c.$");
+        assert_eq!(ast_as_str(parse("abc").unwrap()), "ab.c.");
     }
 
     #[test]
     fn test_parser_conditional() {
-        assert_eq!(ast_as_str(parse("ab?c").unwrap()), "ab?.c.$");
+        assert_eq!(ast_as_str(parse("ab?c").unwrap()), "ab?.c.");
     }
 
     #[test]
     fn test_parser_star() {
-        assert_eq!(ast_as_str(parse("ab*c").unwrap()), "ab*.c.$");
+        assert_eq!(ast_as_str(parse("ab*c").unwrap()), "ab*.c.");
     }
 
     #[test]
     fn test_parser_plus() {
-        assert_eq!(ast_as_str(parse("ab+c").unwrap()), "ab+.c.$");
+        assert_eq!(ast_as_str(parse("ab+c").unwrap()), "ab+.c.");
     }
 
     #[test]
     fn test_parser_whitespace() {
-        assert_eq!(ast_as_str(parse("a c").unwrap()), "a .c.$");
-        assert_eq!(ast_as_str(parse(" ab").unwrap()), " a.b.$");
-        assert_eq!(ast_as_str(parse("ab ").unwrap()), "ab. .$");
+        assert_eq!(ast_as_str(parse("a c").unwrap()), "a .c.");
+        assert_eq!(ast_as_str(parse(" ab").unwrap()), " a.b.");
+        assert_eq!(ast_as_str(parse("ab ").unwrap()), "ab. .");
     }
 
     #[test]
     fn test_parser_parentheses() {
-        assert_eq!(ast_as_str(parse("(a)").unwrap()), "a$");
-        assert_eq!(ast_as_str(parse("(ab)c").unwrap()), "ab.c.$");
-        assert_eq!(ast_as_str(parse("a(bc)").unwrap()), "abc..$");
-        assert_eq!(ast_as_str(parse("(a(bc))d").unwrap()), "abc..d.$");
-        assert_eq!(ast_as_str(parse("(a|b)").unwrap()), "a|b$");
-        assert_eq!(ast_as_str(parse("(a|b)c").unwrap()), "a|bc.$"); // TODO not a great representation
+        assert_eq!(ast_as_str(parse("(a)").unwrap()), "a");
+        assert_eq!(ast_as_str(parse("(ab)c").unwrap()), "ab.c.");
+        assert_eq!(ast_as_str(parse("a(bc)").unwrap()), "abc..");
+        assert_eq!(ast_as_str(parse("(a(bc))d").unwrap()), "abc..d.");
+        assert_eq!(ast_as_str(parse("(a|b)").unwrap()), "a|b");
+        assert_eq!(ast_as_str(parse("(a|b)c").unwrap()), "a|bc."); // TODO not a great representation
     }
 
     #[test]
     fn test_parser_exact_quantifier() {
-        assert_eq!(ast_as_str(parse("a{2}").unwrap()), "a{2}$");
-        assert_eq!(ast_as_str(parse("a{20}").unwrap()), "a{20}$");
+        assert_eq!(ast_as_str(parse("a{2}").unwrap()), "a{2}");
+        assert_eq!(ast_as_str(parse("a{20}").unwrap()), "a{20}");
     }
 
     #[test]
     fn test_parser_exact_quantifier_dist() {
-        assert_eq!(ast_as_str(parse("a{2~Geo(1.0)}").unwrap()), "a{2~Geo(1)}$");
+        assert_eq!(ast_as_str(parse("a{2~Geo(1.0)}").unwrap()), "a{2~Geo(1)}");
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -210,6 +210,26 @@ mod test {
     }
 
     #[test]
+    fn test_parser_anchor_end_ast() {
+        let result = parse("a$").unwrap_or(vec![]);
+        let expected = vec![
+            AstNode {
+                length: 1,
+                kind: Kind::Literal('a'),
+            },
+            AstNode {
+                length: 1,
+                kind: Kind::AnchorEnd,
+            },
+            AstNode {
+                length: 0,
+                kind: Kind::Terminal,
+            },
+        ];
+        assert_eq!(result, expected);
+    }
+
+    #[test]
     fn test_parser_concat_length() {
         let result = parse("ab").unwrap_or(vec![]).first().unwrap().to_owned();
         assert_eq!(result.length, 2);

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -78,6 +78,7 @@ mod test {
             State::terminal(),
         ];
         assert_eq!(matches(&nfa, "bb"), false);
+        assert_eq!(matches(&nfa, "ab"), true);
         assert_eq!(matches(&nfa, "xab"), true);
     }
 

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -34,19 +34,20 @@ mod test {
     #[test]
     fn test_matches_simple_literal() {
         let nfa = vec![
+            State::anchor_start(Some(1)),
             State::from(
                 AstNode {
                     length: 1,
                     kind: Kind::Literal('a'),
                 },
-                (Some(1), None),
+                (Some(2), None),
             ),
             State::from(
                 AstNode {
                     length: 1,
                     kind: Kind::Literal('b'),
                 },
-                (Some(2), None),
+                (Some(3), None),
             ),
             State::terminal(),
         ];
@@ -57,15 +58,33 @@ mod test {
     }
 
     #[test]
-    fn test_matches_simple_alternation() {
+    fn test_matches_simple_literal_without_start_anchor() {
         let nfa = vec![
+            State::start(Some(1)),
             State::from(
                 AstNode {
                     length: 1,
-                    kind: Kind::Start,
+                    kind: Kind::Literal('a'),
                 },
-                (Some(1), None),
+                (Some(2), None),
             ),
+            State::from(
+                AstNode {
+                    length: 1,
+                    kind: Kind::Literal('b'),
+                },
+                (Some(3), None),
+            ),
+            State::terminal(),
+        ];
+        assert_eq!(matches(&nfa, "bb"), false);
+        assert_eq!(matches(&nfa, "xab"), true);
+    }
+
+    #[test]
+    fn test_matches_simple_alternation() {
+        let nfa = vec![
+            State::anchor_start(Some(1)),
             State::from(
                 AstNode {
                     length: 1,
@@ -99,13 +118,7 @@ mod test {
     #[test]
     fn test_matches_conditional_first() {
         let nfa = vec![
-            State::from(
-                AstNode {
-                    length: 1,
-                    kind: Kind::Start,
-                },
-                (Some(2), None),
-            ),
+            State::anchor_start(Some(2)),
             State::from(
                 AstNode {
                     length: 1,
@@ -140,13 +153,7 @@ mod test {
     #[test]
     fn test_matches_simple_conditional() {
         let nfa = vec![
-            State::from(
-                AstNode {
-                    length: 1,
-                    kind: Kind::Start,
-                },
-                (Some(1), None),
-            ),
+            State::anchor_start(Some(1)),
             State::from(
                 AstNode {
                     length: 1,
@@ -273,7 +280,7 @@ mod test {
     #[test]
     fn test_matches_exact_quantifier() {
         let nfa = vec![
-            State::start(Some(1)),
+            State::anchor_start(Some(1)),
             State::from(
                 AstNode {
                     length: 1,

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -14,8 +14,15 @@ pub fn match_p(nfa: &Vec<State>, string: &str) -> Option<f64> {
     let mut state = NfaState::new(nfa);
     state.init_state(Some(0), true);
 
-    // step through string
-    let p = utils::find_max(string.chars().map(|c| state.step(c)));
+    let tokens = [
+        vec![Kind::Start],
+        string.chars().map(Kind::Literal).collect::<Vec<_>>(),
+        vec![Kind::Terminal],
+    ]
+    .concat();
+
+    // step through vector of tokens
+    let p = utils::find_max(tokens.into_iter().map(|t| state.step(t)));
     Some(p)
 }
 
@@ -187,9 +194,10 @@ mod test {
         ];
         assert_eq!(matches(&nfa, "a"), false);
         assert_eq!(matches(&nfa, "ab"), false);
+        assert_eq!(matches(&nfa, "axc"), false);
+        assert_eq!(matches(&nfa, "abc"), true);
         assert_eq!(matches(&nfa, "abbc"), false);
         assert_eq!(matches(&nfa, "ac"), true);
-        assert_eq!(matches(&nfa, "abc"), true);
         assert_eq!(matches(&nfa, "abcx"), true);
         assert_eq!(matches(&nfa, "xabc"), false);
     }
@@ -197,85 +205,89 @@ mod test {
     #[test]
     fn test_matches_simple_plus() {
         let nfa = vec![
+            State::start(Some(1)),
             State::from(
                 AstNode {
                     length: 1,
                     kind: Kind::Literal('a'),
                 },
-                (Some(1), None),
+                (Some(2), None),
             ),
             State::from(
                 AstNode {
                     length: 1,
                     kind: Kind::Literal('b'),
                 },
-                (Some(2), None),
+                (Some(3), None),
             ),
             State::from(
                 AstNode {
                     length: 1,
                     kind: Kind::Quantifier('+'),
                 },
-                (Some(1), Some(3)),
+                (Some(2), Some(4)),
             ),
             State::from(
                 AstNode {
                     length: 1,
                     kind: Kind::Literal('c'),
                 },
-                (Some(4), None),
+                (Some(5), None),
             ),
             State::terminal(),
         ];
         assert_eq!(matches(&nfa, "a"), false);
         assert_eq!(matches(&nfa, "ab"), false);
+        assert_eq!(matches(&nfa, "axc"), false);
+        assert_eq!(matches(&nfa, "abc"), true);
         assert_eq!(matches(&nfa, "abbc"), true);
         assert_eq!(matches(&nfa, "ac"), false);
-        assert_eq!(matches(&nfa, "abc"), true);
         assert_eq!(matches(&nfa, "abcx"), true);
-        assert_eq!(matches(&nfa, "xabc"), false);
+        assert_eq!(matches(&nfa, "xabc"), true);
     }
 
     #[test]
     fn test_matches_simple_star() {
         let nfa = vec![
+            State::start(Some(1)),
             State::from(
                 AstNode {
                     length: 1,
                     kind: Kind::Literal('a'),
                 },
-                (Some(2), None),
+                (Some(3), None),
             ),
             State::from(
                 AstNode {
                     length: 1,
                     kind: Kind::Literal('b'),
                 },
-                (Some(2), None),
+                (Some(3), None),
             ),
             State::from(
                 AstNode {
                     length: 1,
                     kind: Kind::Quantifier('*'),
                 },
-                (Some(1), Some(3)),
+                (Some(2), Some(4)),
             ),
             State::from(
                 AstNode {
                     length: 1,
                     kind: Kind::Literal('c'),
                 },
-                (Some(4), None),
+                (Some(5), None),
             ),
             State::terminal(),
         ];
         assert_eq!(matches(&nfa, "a"), false);
         assert_eq!(matches(&nfa, "ab"), false);
+        assert_eq!(matches(&nfa, "abc"), true);
+        assert_eq!(matches(&nfa, "axc"), false);
         assert_eq!(matches(&nfa, "abbc"), true);
         assert_eq!(matches(&nfa, "ac"), true);
-        assert_eq!(matches(&nfa, "abc"), true);
         assert_eq!(matches(&nfa, "abcx"), true);
-        assert_eq!(matches(&nfa, "xabc"), false);
+        assert_eq!(matches(&nfa, "xabc"), true);
     }
 
     #[test]

--- a/src/state.rs
+++ b/src/state.rs
@@ -336,6 +336,62 @@ mod test {
             vec![&2]
         );
 
+        assert_eq!(state.step('c'), 1.0);
+        assert_eq!(
+            state.current_states.iter().collect::<Vec<&usize>>(),
+            vec![&3]
+        );
+
+        assert_eq!(state.step('d'), 1.0);
+        assert_eq!(
+            state.current_states.iter().collect::<Vec<&usize>>(),
+            Vec::<&usize>::new()
+        );
+        assert_eq!(state.visited.len(), 0);
+    }
+
+    #[test]
+    fn test_state_not_match() {
+        let nfa = vec![
+            State::from(
+                AstNode {
+                    length: 1,
+                    kind: Kind::Literal('a'),
+                },
+                (Some(1), None),
+            ),
+            State::from(
+                AstNode {
+                    length: 1,
+                    kind: Kind::Literal('b'),
+                },
+                (Some(2), None),
+            ),
+            State::from(
+                AstNode {
+                    length: 1,
+                    kind: Kind::Literal('c'),
+                },
+                (Some(3), None),
+            ),
+            State::terminal(),
+        ];
+        let mut state = NfaState::new(&nfa);
+        state.init_state(Some(0), true);
+        assert_eq!(state.current_states.len(), 1);
+
+        assert_eq!(state.step('a'), 0.0);
+        assert_eq!(
+            state.current_states.iter().collect::<Vec<&usize>>(),
+            vec![&1]
+        );
+
+        assert_eq!(state.step('b'), 0.0);
+        assert_eq!(
+            state.current_states.iter().collect::<Vec<&usize>>(),
+            vec![&2]
+        );
+
         assert_eq!(state.step('x'), 0.0);
         assert_eq!(
             state.current_states.iter().collect::<Vec<&usize>>(),
@@ -362,13 +418,7 @@ mod test {
                 },
                 (Some(2), None),
             ),
-            State::from(
-                AstNode {
-                    length: 1,
-                    kind: Kind::Terminal,
-                },
-                (None, None),
-            ),
+            State::terminal()
         ];
         let mut state = NfaState::new(&nfa);
         state.init_state(Some(0), true);

--- a/src/state.rs
+++ b/src/state.rs
@@ -88,8 +88,13 @@ impl NfaState<'_> {
                         self.add_state(state.outs.1, force, p),
                     );
                 }
+                Kind::AnchorStart => {
+                    return f64::max(
+                        self.add_state(state.outs.0, force, p),
+                        self.add_state(state.outs.1, force, p),
+                    );
+                }
                 Kind::Quantifier(_)
-                | Kind::AnchorStart
                 | Kind::Split
                 | Kind::ExactQuantifier(_) => {
                     let params = self.get_params_mut(idx);
@@ -157,7 +162,7 @@ impl NfaState<'_> {
                         add_new_state(state.outs.1, p);
                     }
                 }
-                Kind::Start => {
+                Kind::Start | Kind::AnchorStart => {
                     add_new_state(Some(*i), p);
                 }
                 _ => {}


### PR DESCRIPTION
Implement start (`^`) and end (`$`) anchors.

This works by introducing `Kind::AnchorStart` and `Kind::AnchorEnd` AST nodes and instead of stepping through string *characters*, we step through *tokens* such as `[Kind::Start, Kind::Literal('a'), ..., Kind::Terminal]`.