### PR TITLE
Character classes

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -146,12 +146,10 @@ pub fn build_ast_from_expr(pair: Pair<Rule>) -> AstNode {
                 None => left_ast,
             }
         }
-        Rule::CharacterClass | Rule::ShortClass | Rule::PosixClass => {
-            AstNode {
-                length: 1,
-                kind: Kind::Class(build_chars(pair)),
-            }
-        }
+        Rule::CharacterClass | Rule::ShortClass | Rule::PosixClass => AstNode {
+            length: 1,
+            kind: Kind::Class(build_chars(pair)),
+        },
         Rule::EOI => AstNode {
             length: 0,
             kind: Kind::Terminal,

--- a/src/charclass.rs
+++ b/src/charclass.rs
@@ -15,7 +15,12 @@ pub fn build_chars(pair: Pair<Rule>) -> Vec<char> {
         }
         Rule::CharacterClass => {
             let pairs = pair.into_inner();
-            let chars: Vec<char> = pairs.map(|r| r.as_str().chars().next().unwrap()).collect();
+            let chars: Vec<char> = pairs
+                .flat_map(|p| match p.as_rule() {
+                    Rule::PosixClass | Rule::ShortClass => build_chars(p),
+                    _ => p.as_str().chars().collect(),
+                })
+                .collect();
             chars
         }
         _ => vec![],

--- a/src/charclass.rs
+++ b/src/charclass.rs
@@ -1,0 +1,21 @@
+use pest::iterators::Pair;
+
+use crate::parser::Rule;
+
+pub fn build_chars(pair: Pair<Rule>) -> Vec<char> {
+    match pair.as_rule() {
+        Rule::ShortClass => {
+            let name = pair.as_str();
+            let chars = match name {
+                _ => panic!("Unknown character class {}", name),
+            };
+            chars
+        }
+        Rule::CharacterClass => {
+            let pairs = pair.into_inner();
+            let chars: Vec<char> = pairs.map(|r| r.as_str().chars().next().unwrap()).collect();
+            chars
+        }
+        _ => vec![],
+    }
+}

--- a/src/charclass.rs
+++ b/src/charclass.rs
@@ -4,9 +4,11 @@ use crate::parser::Rule;
 
 pub fn build_chars(pair: Pair<Rule>) -> Vec<char> {
     match pair.as_rule() {
-        Rule::ShortClass => {
+        Rule::PosixClass | Rule::ShortClass => {
             let name = pair.as_str();
             let chars = match name {
+                "[:digit:]" | "\\d" => vec!['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'],
+                "[:space:]" | "\\s" => vec![' ', '\t', '\n', '\r', '\x0c', '\x0b'],
                 _ => panic!("Unknown character class {}", name),
             };
             chars

--- a/src/distribution.rs
+++ b/src/distribution.rs
@@ -189,7 +189,7 @@ impl Dist {
 /// Calculates the probability mass function for the zipf distribution at `x`
 fn zipf(x: usize, s: f64, n: usize) -> f64 {
     let normalizer: f64 = (1..(n + 1)).map(|n_i| 1.0 / (n_i as f64).powf(s)).sum();
-    return (1.0 / (x as f64).powf(s)) / normalizer;
+    (1.0 / (x as f64).powf(s)) / normalizer
 }
 
 #[cfg(test)]

--- a/src/grammar.pest
+++ b/src/grammar.pest
@@ -17,9 +17,9 @@ Dot             =  { "." }
 
 Class           = _{ ShortClass | LongClass }
 ShortClass      =  { "\\w" | "\\s" | "\\d" }
-LongClass       =  { "[" ~ (PosixClass | CharacterClass) ~ Dist? ~ "]" }
+LongClass       =  { "[" ~ (PosixClass | CharacterClass | ShortClass) ~ Dist? ~ "]" }
 PosixClass      =  { "[:digit:]" | "[:space:]" }
-CharacterClass  =  { Token+ }
+CharacterClass  =  { ( Literal | Dot | ShortClass )+ }
 
 Quantifier      = _{ ShortQuantifier | LongQuantifier }
 ShortQuantifier =  { "+" | "?" | "*" }

--- a/src/grammar.pest
+++ b/src/grammar.pest
@@ -10,19 +10,24 @@ Concat          =  { Factor ~ Factor }
 Group           = _{ "(" ~ ( Alternation | Expression ) ~ ")" }
 
 Factor          = _{ Quantified | Group | Token }
-Token           = _{ Literal | Dot }
+Token           = _{ Literal | Dot | Class }
 Quantified      =  { ( Token | Group ) ~ Quantifier }
 Literal         =  { ASCII_ALPHANUMERIC | " " }
 Dot             =  { "." }
 
+Class           = _{ LongClass }
+LongClass       =  { "[" ~ ( CharacterClass) ~ Dist? ~ "]" }
+CharacterClass  =  { Token+ }
+
 Quantifier      = _{ ShortQuantifier | LongQuantifier }
 ShortQuantifier =  { "+" | "?" | "*" }
-LongQuantifier  = _{ "{" ~ ExactQuantifier ~ QuantifierDist? ~ "}" }
+LongQuantifier  = _{ "{" ~ ExactQuantifier ~ Dist? ~ "}" }
 ExactQuantifier =  { QuantifierParam }
-
 QuantifierParam =  { ASCII_DIGIT* }
-QuantifierDist  =  { "~" ~ DistName ~ "(" ~ DistParam ~ ")" }
-DistName        =  { ^"Geo" | ^"Bin" | ^"Ber" }
+
+Dist            =  { "~" ~ DistName ~ ( "(" ~ DistParams ~ ")" )? }
+DistName        =  { ^"Geo" | ^"Bin" | ^"Ber" | ^"Zipf" }
+DistParams      = _{ DistParam ~ ("," ~ DistParam)? }
 DistParam       =  { ASCII_FLOAT }
 
 ASCII_FLOAT     = _{ ASCII_DIGIT+ ~ "." ~ ASCII_DIGIT+ }

--- a/src/grammar.pest
+++ b/src/grammar.pest
@@ -15,8 +15,10 @@ Quantified      =  { ( Token | Group ) ~ Quantifier }
 Literal         =  { ASCII_ALPHANUMERIC | " " }
 Dot             =  { "." }
 
-Class           = _{ LongClass }
-LongClass       =  { "[" ~ ( CharacterClass) ~ Dist? ~ "]" }
+Class           = _{ ShortClass | LongClass }
+ShortClass      =  { "\\w" | "\\s" | "\\d" }
+LongClass       =  { "[" ~ (PosixClass | CharacterClass) ~ Dist? ~ "]" }
+PosixClass      =  { "[:digit:]" | "[:space:]" }
 CharacterClass  =  { Token+ }
 
 Quantifier      = _{ ShortQuantifier | LongQuantifier }

--- a/src/grammar.pest
+++ b/src/grammar.pest
@@ -28,8 +28,11 @@ ExactQuantifier =  { QuantifierParam }
 QuantifierParam =  { ASCII_DIGIT* }
 
 Dist            =  { "~" ~ DistName ~ ( "(" ~ DistParams ~ ")" )? }
-DistName        =  { ^"Geo" | ^"Bin" | ^"Ber" | ^"Zipf" }
+DistName        =  { ^"Geo" | ^"Bin" | ^"Ber" | ^"Const" | ^"Zipf" }
 DistParams      = _{ DistParam ~ ("," ~ DistParam)? }
-DistParam       =  { ASCII_FLOAT }
+DistParam       = _{ IndexParam | NamedParam }
+IndexParam      =  { FLOAT_NUMBER }
+NamedParam      =  { ASCII_ALPHA ~ "=" ~ ( FLOAT_NUMBER | ASCII_DIGIT+ ) }
 
-ASCII_FLOAT     = _{ ASCII_DIGIT+ ~ "." ~ ASCII_DIGIT+ }
+
+FLOAT_NUMBER    = _{ ASCII_DIGIT+ ~ "." ~ ASCII_DIGIT+ }

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,7 +62,7 @@ fn input_reader(config: &cli::Config) -> Result<BufReader<Box<dyn Read>>> {
             config
                 .input_string
                 .as_ref()
-                .and_then(|s| Some(s.to_string()))
+                .map(|s| s.to_string())
                 .expect("input string to have been specified"),
         )),
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ use {
 };
 
 mod ast;
+mod charclass;
 mod cli;
 mod distribution;
 mod nfa;

--- a/src/nfa.rs
+++ b/src/nfa.rs
@@ -9,18 +9,6 @@ pub struct State {
     pub dist: Option<Dist>,
 }
 
-#[derive(Debug, PartialEq)]
-pub struct StateParams {
-    pub p: f64, // current p
-    pub n: u64, // visit count
-}
-
-impl StateParams {
-    pub fn new(p: f64, n: u64) -> Self {
-        Self { p, n }
-    }
-}
-
 impl State {
     pub fn new(kind: Kind, outs: Outs, dist: Option<Dist>) -> State {
         State { kind, outs, dist }
@@ -62,6 +50,7 @@ impl State {
             dist: None,
         }
     }
+    #[allow(dead_code)]
     pub fn literal(char: char, outs: Outs) -> State {
         State {
             kind: Kind::Literal(char),
@@ -69,6 +58,7 @@ impl State {
             dist: None,
         }
     }
+    #[allow(dead_code)]
     pub fn split(outs: Outs) -> State {
         State {
             kind: Kind::Split,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -223,6 +223,38 @@ mod test {
     }
 
     #[test]
+    fn test_parser_short_class_ast() {
+        let result = parse("\\d").unwrap_or_default();
+        let expected = vec![
+            AstNode {
+                length: 1,
+                kind: Kind::Class(vec!['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'], None),
+            },
+            AstNode {
+                length: 0,
+                kind: Kind::Terminal,
+            },
+        ];
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_parser_posix_class_ast() {
+        let result = parse("[[:digit:]]").unwrap_or_default();
+        let expected = vec![
+            AstNode {
+                length: 1,
+                kind: Kind::Class(vec!['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'], None),
+            },
+            AstNode {
+                length: 0,
+                kind: Kind::Terminal,
+            },
+        ];
+        assert_eq!(result, expected);
+    }
+
+    #[test]
     fn test_parser_anchor_start_ast() {
         let result = parse("^a").unwrap_or_default();
         let expected = vec![

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -364,4 +364,9 @@ mod test {
     fn test_parser_exact_class() {
         assert_eq!(ast_as_str(parse("[ab]").unwrap()), "[ab]");
     }
+
+    #[test]
+    fn test_parser_exact_class_with_dist() {
+        assert_eq!(ast_as_str(parse("[ab~Const]").unwrap()), "[[ab]]");
+    }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -196,7 +196,7 @@ mod test {
         let expected = vec![
             AstNode {
                 length: 1,
-                kind: Kind::Class(vec!['a', 'b', 'c'], None),
+                kind: Kind::Class(vec!['a', 'b', 'c']),
             },
             AstNode {
                 length: 0,
@@ -212,7 +212,13 @@ mod test {
         let expected = vec![
             AstNode {
                 length: 1,
-                kind: Kind::Class(vec!['a', 'b', 'c'], Some(Dist::PGeometric(1, 0.5))),
+                kind: Kind::Classified(
+                    Box::new(AstNode {
+                        length: 1,
+                        kind: Kind::Class(vec!['a', 'b', 'c']),
+                    }),
+                    Some(Dist::PGeometric(0, 0.5)),
+                ),
             },
             AstNode {
                 length: 0,
@@ -228,7 +234,7 @@ mod test {
         let expected = vec![
             AstNode {
                 length: 1,
-                kind: Kind::Class(vec!['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'], None),
+                kind: Kind::Class(vec!['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']),
             },
             AstNode {
                 length: 0,
@@ -244,7 +250,7 @@ mod test {
         let expected = vec![
             AstNode {
                 length: 1,
-                kind: Kind::Class(vec!['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'], None),
+                kind: Kind::Class(vec!['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']),
             },
             AstNode {
                 length: 0,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -191,6 +191,38 @@ mod test {
     }
 
     #[test]
+    fn test_parser_exact_class_ast() {
+        let result = parse("[abc]").unwrap_or_default();
+        let expected = vec![
+            AstNode {
+                length: 1,
+                kind: Kind::Class(vec!['a', 'b', 'c'], None),
+            },
+            AstNode {
+                length: 0,
+                kind: Kind::Terminal,
+            },
+        ];
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_parser_exact_class_dist_ast() {
+        let result = parse("[abc~Geo(0.5)]").unwrap_or_default();
+        let expected = vec![
+            AstNode {
+                length: 1,
+                kind: Kind::Class(vec!['a', 'b', 'c'], Some(Dist::PGeometric(1, 0.5))),
+            },
+            AstNode {
+                length: 0,
+                kind: Kind::Terminal,
+            },
+        ];
+        assert_eq!(result, expected);
+    }
+
+    #[test]
     fn test_parser_anchor_start_ast() {
         let result = parse("^a").unwrap_or_default();
         let expected = vec![
@@ -288,5 +320,10 @@ mod test {
     #[test]
     fn test_parser_exact_quantifier_dist() {
         assert_eq!(ast_as_str(parse("a{2~Geo(1.0)}").unwrap()), "a{2~Geo(1)}");
+    }
+
+    #[test]
+    fn test_parser_exact_class() {
+        assert_eq!(ast_as_str(parse("[ab]").unwrap()), "[ab]");
     }
 }

--- a/src/regex.rs
+++ b/src/regex.rs
@@ -156,7 +156,7 @@ mod test {
         let counts = add_counts(&states, &counts);
         assert_eq!(counts, [(1, 2), (2, 1)].into());
         let states = step_states(states, &counts, &Kind::Literal('a'), &nfa);
-        assert_eq!(states, [(1, 0.0), (2, 1.0), (3, 1.0)].into());
+        assert_eq!(states, [(1, 1.0), (2, 1.0), (3, 1.0)].into());
 
         let counts = add_counts(&states, &counts);
         let states = step_states(states, &counts, &Kind::Literal('b'), &nfa);
@@ -186,11 +186,11 @@ mod test {
 
         let states = step_states(states, &counts, &Kind::Literal('a'), &nfa);
         let counts = add_counts(&states, &counts);
-        assert_eq!(states, [(1, 0.5), (2, 1.0), (3, 0.5)].into());
+        assert_eq!(states, [(1, 1.0), (2, 1.0), (3, 0.5)].into());
 
         let states = step_states(states, &counts, &Kind::Literal('a'), &nfa);
         let counts = add_counts(&states, &counts);
-        assert_eq!(states, [(1, 0.75), (2, 1.0), (3, 0.25)].into());
+        assert_eq!(states, [(1, 1.0), (2, 1.0), (3, 0.25)].into());
 
         let states = step_states(states, &counts, &Kind::Literal('b'), &nfa);
         assert_eq!(states, [(4, 0.25)].into());

--- a/src/regex.rs
+++ b/src/regex.rs
@@ -15,7 +15,7 @@ where
     T: Into<Tokens> + Clone,
 {
     let mut states = initial_state(nfa, false);
-    let mut counts: HashMap<usize, u64> = HashMap::new();
+    let mut counts = HashMap::new();
     let tokens: Vec<Token> = input.clone().into().as_vec();
 
     for token in tokens.iter() {
@@ -37,7 +37,7 @@ fn step_states(
     let mut next: HashMap<usize, f64> = HashMap::new();
     for (state, p) in states.iter() {
         let state = Some(*state);
-        let transitions = evaluate_state(state, token, *p, &nfa, &counts, &states, false);
+        let transitions = evaluate_state(state, token, *p, nfa, counts, &states, false);
         for transition in transitions {
             if let Transition(Some(out), new_p) = transition {
                 let old_p = next.entry(out).or_insert(new_p);

--- a/src/regex_state.rs
+++ b/src/regex_state.rs
@@ -15,7 +15,7 @@ pub fn initial_state(nfa: &Vec<State>, skip_start: bool) -> HashMap<usize, f64> 
         Some(0),
         &Kind::Start,
         1.0,
-        &nfa,
+        nfa,
         &HashMap::new(),
         &HashMap::new(),
         // for simpler testing (n need for Kind::Start token everywhere)

--- a/src/regex_state.rs
+++ b/src/regex_state.rs
@@ -126,6 +126,23 @@ pub fn evaluate_state(
                     }
                 }
             }
+            Kind::Class(ref match_c) => {
+                if is_epsilon {
+                    return vec![Transition(Some(idx), p)];
+                }
+                let (n, c) = match token {
+                    Kind::Literal(c) => match match_c.iter().position(|&r| r == *c) {
+                        Some(i) => (i as u64, *c),
+                        None => return vec![],
+                    },
+                    _ => return vec![],
+                };
+                let (_, p1) = match &state.dist {
+                    Some(dist) => dist.evaluate_char(c, n, false),
+                    None => (1., 1.),
+                };
+                return evaluate_state(state.outs.0, token, p * p1, nfa, counts, states, true);
+            }
             _ => {}
         }
     }

--- a/src/visualization.rs
+++ b/src/visualization.rs
@@ -14,7 +14,7 @@ pub fn debug_print(
     nfa: &Vec<State>,
     token: &Kind,
 ) {
-    for (i, _) in nfa.iter().enumerate() {
+    for (i, state) in nfa.iter().enumerate() {
         // let (p, n) = match states.get(&i) {
         //     Some((p, n)) => (f64::clamp(p * 4.0, 0., 4.) as usize, *n as u8),
         //     None => (0, 1),
@@ -23,10 +23,11 @@ pub fn debug_print(
             Some(n) => usize::clamp(*n as usize, 0, 4),
             None => 0,
         };
+        let s_len = state.kind.to_string().len();
         let s = String::from(char::from_u32(0x2800 + PIXEL_MAP[n] as u32).unwrap());
-        print!("{}", s);
+        print!("{: <width$}", s, width = s_len);
     }
-    println!("");
+    println!();
     for (i, state) in nfa.iter().enumerate() {
         let c = match states.get(&i) {
             Some(p) => (
@@ -44,7 +45,7 @@ pub fn debug_print(
     let probs = states
         .keys()
         .sorted()
-        .map(|i| format!("p({})={:?}", nfa[*i].kind, states[i]))
+        .map(|i| format!("p({})={:.4}", nfa[*i].kind, states[i]))
         .collect::<Vec<String>>();
     println!("{}", probs.join(" ").cyan());
 }


### PR DESCRIPTION
Implement character classes, in short:
* implement character classes `[abc]`
* implement naive shorthand classes `\d\s` and the POSIX equivalents `[:digit:][:space:]`
* implement character class distributions `[abc~Zipf(0.7)]`
* add `Const` and `Zipf` distributions
* add defaults to distributions, so they can be used in short form `a{2~Geo}`
* (allow supplying distribution parameters in named form `Foo(a=0.1,b=2)`)

This makes it possible to do a crude English matcher based on [letter frequencies](https://en.wikipedia.org/wiki/Letter_frequency) and the [Zipf distribution](https://mathworld.wolfram.com/ZipfDistribution.html) such as
```sh
$> pregex "^[etaoinshrdlcumwfgypbvkjxqz~Zipf(0.6)]$" "e"
0.13660 e
# which is roughly freq(e) in english
$> pregex "^[etaoinshrdlcumwfgypbvkjxqz~Zipf(0.7)]{3}$" "eat"
0.00087 eat
# which is freq(e)*freq(a)*freq(t) in english
$> pregex "^[etaoinshrdlcumwfgypbvkjxqz~Zipf(0.7)]{3}$" "foo"
0.00009 foo
# which is freq(f)*freq(o)*freq(o) in english
```

and combine quantifier distributions with character class distributions such as
```sh
$> pregex "^[ab~Geo(0.5)]{3~Geo(0.5)}$" "aaa"
0.06250 aaa
# which is (0.5 * 0.5 * 0.5) * 0.5
$> pregex "^[ab~Geo(0.5)]{3~Geo(0.5)}$" "aab"
0.03125 aab
# which is (0.5 * 0.5 * 0.25) * 0.5
$> pregex "^[ab~Geo(0.5)]{3~Geo(0.5)}$" "aaab"
0.00781 aaab
# which is (0.5 * 0.5 * 0.5 * 0.25) * 0.25
```
where character class calculation takes precedence.