### PR TITLE
Categorical distribution

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,5 +1,5 @@
 use crate::charclass::build_chars;
-use crate::distribution::Dist;
+use crate::distribution::{Dist, DistLink};
 use crate::parser::Rule;
 use itertools::Itertools;
 use pest::iterators::Pair;
@@ -23,9 +23,9 @@ pub enum Kind {
     Split,
     Start,
     Terminal,
-    Classified(Box<AstNode>, Option<Dist>),
+    Classified(Box<AstNode>, Option<DistLink>),
     Class(Vec<char>),
-    Quantified(Box<AstNode>, Box<AstNode>, Option<Dist>),
+    Quantified(Box<AstNode>, Box<AstNode>, Option<DistLink>),
     Quantifier(char),
 }
 
@@ -114,7 +114,7 @@ pub fn build_ast_from_expr(pair: Pair<Rule>) -> AstNode {
                 kind: Kind::Quantified(
                     Box::new(quantifier_ast),
                     Box::new(left_ast),
-                    quantifier_dist,
+                    quantifier_dist.map(|d| DistLink::Counted(d)),
                 ),
             }
         }
@@ -141,7 +141,7 @@ pub fn build_ast_from_expr(pair: Pair<Rule>) -> AstNode {
             match class_dist {
                 Some(dist) => AstNode {
                     length: 1,
-                    kind: Kind::Classified(Box::new(left_ast), Some(dist)),
+                    kind: Kind::Classified(Box::new(left_ast), Some(DistLink::Indexed(dist))),
                 },
                 None => left_ast,
             }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -34,7 +34,10 @@ impl fmt::Display for Kind {
         match &self {
             Kind::Literal(c) => write!(f, "{}", c),
             Kind::Dot => write!(f, "."),
-            Kind::Class(c) => write!(f, "[{}]", c.iter().join("")),
+            Kind::Class(c) => match c.len() > 5 {
+                true => write!(f, "[{}..]", c.iter().take(3).join("")),
+                false => write!(f, "[{}]", c.iter().join("")),
+            },
             Kind::Classified(l, d) => match d {
                 Some(d) => write!(f, "[{}{}]", l, d),
                 None => write!(f, "[{}]", l),

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -139,6 +139,13 @@ pub fn build_ast_from_expr(pair: Pair<Rule>) -> AstNode {
                 None => None,
             };
             match class_dist {
+                Some(Dist::Categorical(_)) => AstNode {
+                    length: 1,
+                    kind: Kind::Classified(
+                        Box::new(left_ast),
+                        Some(DistLink::Indexed(class_dist.unwrap())),
+                    ),
+                },
                 Some(dist) => AstNode {
                     length: 1,
                     kind: Kind::Classified(Box::new(left_ast), Some(DistLink::Indexed(dist))),

--- a/src/distribution.rs
+++ b/src/distribution.rs
@@ -32,7 +32,6 @@ impl fmt::Display for Dist {
             Dist::PBinomial(_, p) => write!(f, "~Bin({})", p),
             Dist::PBernoulli(_, p) => write!(f, "~Ber({})", p),
             Dist::PZipf(_, p) => write!(f, "~Zipf({})", p),
-            Dist::Map(p) => write!(f, "~Freq({:?})", p),
         }
     }
 }
@@ -238,10 +237,6 @@ impl Dist {
     pub fn index(self) -> DistLink {
         DistLink::Indexed(self)
     }
-
-    pub fn mapped(self, map: HashMap<char, u64>) -> DistLink {
-        DistLink::Mapped(self, map)
-    }
 }
 
 /// Calculates the probability mass function for the zipf distribution at `x`
@@ -257,8 +252,6 @@ pub enum DistLink {
     Counted(Dist),
     /// Distribution indexed by token position
     Indexed(Dist),
-    /// Distribution indexed by token value in map
-    Mapped(Dist, HashMap<char, u64>),
 }
 
 impl DistLink {
@@ -286,17 +279,6 @@ impl DistLink {
                     _ => (0., 0.),
                 }
             }
-            DistLink::Mapped(d, map) => {
-                let c = match token {
-                    Kind::Literal(c) => c,
-                    _ => return (0., 0.),
-                };
-
-                match map.get(c) {
-                    Some(idx) => d.evaluate(Some(*idx), log),
-                    None => (0., 0.),
-                }
-            }
         }
     }
 }
@@ -306,9 +288,6 @@ impl fmt::Display for DistLink {
         match &self {
             DistLink::Counted(d) | DistLink::Indexed(d) => {
                 write!(f, "{}", d)
-            }
-            DistLink::Mapped(d, m) => {
-                write!(f, "{}={:?}", d, m)
             }
         }
     }

--- a/src/distribution.rs
+++ b/src/distribution.rs
@@ -6,25 +6,26 @@ use crate::regex_state::Token;
 use itertools::Itertools;
 
 use pest::iterators::Pair;
-use statrs::distribution::{Bernoulli, Binomial, Discrete, Geometric};
+use statrs::distribution::{Bernoulli, Binomial, Categorical, Discrete, Geometric};
 use statrs::statistics::Distribution;
 use std::collections::{HashMap, HashSet};
 use std::fmt;
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum Dist {
-    Constant(f64),        // p
-    ExactlyTimes(u64),    // n_match
-    PGeometric(u64, f64), // n_min, p
-    PBinomial(u64, f64),  // n_max, p
-    PBernoulli(u64, f64), // n_max, p
-    PZipf(u64, f64),      // n_max, s
-    Map(HashMap<char, f64>), // chr -> p
+    Categorical(Vec<f64>), // p[]
+    Constant(f64),         // p
+    ExactlyTimes(u64),     // n_match
+    PGeometric(u64, f64),  // n_min, p
+    PBinomial(u64, f64),   // n_max, p
+    PBernoulli(u64, f64),  // n_max, p
+    PZipf(u64, f64),       // n_max, s
 }
 
 impl fmt::Display for Dist {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Dist::Categorical(_) => write!(f, "~Cat"),
             Dist::Constant(_) => write!(f, ""),
             Dist::ExactlyTimes(n) => write!(f, ""),
             Dist::PGeometric(_, p) => write!(f, "~Geo({})", p),
@@ -99,6 +100,39 @@ impl Dist {
                 let p: f64 = params.first().unwrap_or(&"1.0").parse().unwrap();
                 Dist::PBernoulli(n, p)
             }
+            "cat" => {
+                let params_named: HashMap<char, f64> = params_named
+                    .into_iter()
+                    .map(|(k, v)| (k.chars().next().unwrap(), v.parse().unwrap()))
+                    .collect();
+                let n_explicit = params_named.iter().filter(|&(k, _)| *k != '.').count();
+                let n_implicit = match c {
+                    Some(chars) => usize::max(1, chars.len() - n_explicit),
+                    None => 1,
+                };
+
+                // Sum of probability masses with given weight
+                let explicit_mass = params_named.values().sum::<f64>();
+                let implicit_mass = f64::max(0.0, 1.0 - explicit_mass);
+
+                // Probability mass for valid character without given weight
+                let p_implicit: f64 = f64::max(0.0, implicit_mass) / n_implicit as f64;
+                let mut prob_mass: Vec<f64> = c
+                    .expect("chars to be passed")
+                    .iter()
+                    .map(|c| *params_named.get(c).unwrap_or(&p_implicit))
+                    .collect();
+
+                let p_remainder: f64 = match params_named.get(&'.') {
+                    Some(v) => *v,
+                    None => f64::max(0.0, 1.0 - prob_mass.iter().sum::<f64>()),
+                };
+
+                // Insert remainder as first item to ensure prob_mass sum is not zero
+                prob_mass.insert(0, p_remainder);
+
+                Dist::Categorical(prob_mass)
+            }
             "zipf" => {
                 let p: f64 = params.first().unwrap_or(&"1.0").parse().unwrap();
                 let n = c.expect("chars to be passed").len() as u64;
@@ -110,14 +144,13 @@ impl Dist {
         }
     }
 
-    /// Evaluate (p0, p1) for state arrows (state.outs)
-    pub fn evaluate(&self, n: u64, log: bool) -> (f64, f64) {
-        // TODO pass variant of Token instead of random character
-        self.evaluate_char('?', n, log)
+    /// Test helper
+    pub fn evaluated(&self, x: u64, log: bool) -> (f64, f64) {
+        self.evaluate(Some(x), log)
     }
 
-    /// Evaluate (p0, p1) for state arrows (state.outs) with character context
-    pub fn evaluate_char(&self, _: char, n: u64, log: bool) -> (f64, f64) {
+    /// Evaluate (p0, p1) for state arrows (state.outs)
+    pub fn evaluate(&self, x: Option<u64>, log: bool) -> (f64, f64) {
         // Special distributions
         match self {
             Dist::Constant(p) => match log {
@@ -125,6 +158,7 @@ impl Dist {
                 false => return (*p, *p),
             },
             Dist::ExactlyTimes(n_match) => {
+                let n = x.unwrap();
                 // does not depend on log
                 if n == *n_match {
                     return (0.0, 1.0);
@@ -140,6 +174,7 @@ impl Dist {
         // Evaluate point mass function from distribution
         let p = match self {
             Dist::PGeometric(n_min, c) => {
+                let n = x.unwrap();
                 if n < *n_min {
                     return (1.0, 0.0);
                 }
@@ -150,6 +185,7 @@ impl Dist {
                 }
             }
             Dist::PBinomial(n_max, p) => {
+                let n = x.unwrap();
                 if n > *n_max {
                     return (0.0, 0.0);
                 }
@@ -160,6 +196,7 @@ impl Dist {
                 }
             }
             Dist::PBernoulli(n_max, p) => {
+                let n = x.unwrap();
                 if n > *n_max {
                     return (1.0, 0.0);
                 }
@@ -170,7 +207,17 @@ impl Dist {
                 }
             }
             Dist::PZipf(n_max, s) => {
+                let n = x.unwrap();
                 let p = zipf(n + 1, *s, *n_max);
+                return (1. - p, p);
+            }
+            Dist::Categorical(prob_mass) => {
+                // Offset match by one since zeroth index is p_rest
+                let x = x.map(|i| i + 1).unwrap_or(0);
+                let p = match log {
+                    true => Categorical::new(prob_mass).unwrap().ln_pmf(x),
+                    false => Categorical::new(prob_mass).unwrap().pmf(x),
+                };
                 return (1. - p, p);
             }
             _ => unreachable!(),
@@ -219,16 +266,21 @@ impl DistLink {
     /// Equivalent to pmf(link(token, n_visits))
     pub fn pmf_link(&self, token: &Token, n_visits: u64, kind: &Kind, log: bool) -> (f64, f64) {
         match self {
-            DistLink::Counted(d) => d.evaluate(n_visits, log),
+            DistLink::Counted(d) => d.evaluate(Some(n_visits), log),
             DistLink::Indexed(d) => {
                 let c = match token {
                     Kind::Literal(c) => c,
-                    _ => return (0., 0.),
+                    _ => {
+                        return (0., 0.);
+                    }
                 };
+
                 match kind {
                     Kind::Class(chars) => match chars.iter().position(|&r| r == *c) {
-                        Some(idx) => d.evaluate(idx as u64, log),
-                        None => (0., 0.),
+                        // match, evaluate for p
+                        Some(idx) => d.evaluate(Some(idx as u64), log),
+                        // no match, evaluate for p_rest
+                        None => d.evaluate(None, log),
                     },
                     _ => (0., 0.),
                 }
@@ -240,7 +292,7 @@ impl DistLink {
                 };
 
                 match map.get(c) {
-                    Some(idx) => d.evaluate(*idx, log),
+                    Some(idx) => d.evaluate(Some(*idx), log),
                     None => (0., 0.),
                 }
             }
@@ -273,72 +325,72 @@ mod test {
 
     #[test]
     fn test_distribution_constant() {
-        assert_eq!(Dist::Constant(1.0).evaluate(1, false), (1.0, 1.0));
-        assert_eq!(Dist::Constant(0.5).evaluate(1, false), (0.5, 0.5));
+        assert_eq!(Dist::Constant(1.0).evaluated(1, false), (1.0, 1.0));
+        assert_eq!(Dist::Constant(0.5).evaluated(1, false), (0.5, 0.5));
     }
 
     #[test]
     fn test_distribution_constant_log() {
-        assert_tuple_nearly_eq(Dist::Constant(1.0).evaluate(1, true), (0., 0.), 0.01);
-        assert_tuple_nearly_eq(Dist::Constant(0.5).evaluate(1, true), (-0.69, -0.69), 0.01);
+        assert_tuple_nearly_eq(Dist::Constant(1.0).evaluated(1, true), (0., 0.), 0.01);
+        assert_tuple_nearly_eq(Dist::Constant(0.5).evaluated(1, true), (-0.69, -0.69), 0.01);
     }
 
     #[test]
     fn test_distribution_exactly_times() {
-        assert_eq!(Dist::ExactlyTimes(2).evaluate(0, false), (1.0, 0.0));
-        assert_eq!(Dist::ExactlyTimes(2).evaluate(1, false), (1.0, 0.0));
-        assert_eq!(Dist::ExactlyTimes(2).evaluate(2, false), (0.0, 1.0));
-        assert_eq!(Dist::ExactlyTimes(2).evaluate(3, false), (0.0, 0.0));
+        assert_eq!(Dist::ExactlyTimes(2).evaluated(0, false), (1.0, 0.0));
+        assert_eq!(Dist::ExactlyTimes(2).evaluated(1, false), (1.0, 0.0));
+        assert_eq!(Dist::ExactlyTimes(2).evaluated(2, false), (0.0, 1.0));
+        assert_eq!(Dist::ExactlyTimes(2).evaluated(3, false), (0.0, 0.0));
     }
 
     #[test]
     #[rustfmt::skip]
     fn test_distribution_geometric_1_or_more() {
-        assert_eq!(Dist::PGeometric(1, 0.5).evaluate( 0, false), (1.0, 0.0));
-        assert_eq!(Dist::PGeometric(1, 0.5).evaluate( 1, false), (0.5, 0.5));
-        assert_eq!(Dist::PGeometric(1, 0.5).evaluate( 2, false), (0.75, 0.25));
+        assert_eq!(Dist::PGeometric(1, 0.5).evaluated( 0, false), (1.0, 0.0));
+        assert_eq!(Dist::PGeometric(1, 0.5).evaluated( 1, false), (0.5, 0.5));
+        assert_eq!(Dist::PGeometric(1, 0.5).evaluated( 2, false), (0.75, 0.25));
     }
 
     #[test]
     fn test_distribution_geometric_2_or_more() {
-        assert_eq!(Dist::PGeometric(2, 0.5).evaluate(0, false), (1.0, 0.0));
-        assert_eq!(Dist::PGeometric(2, 0.5).evaluate(1, false), (1.0, 0.0));
-        assert_eq!(Dist::PGeometric(2, 0.5).evaluate(2, false), (0.5, 0.5));
+        assert_eq!(Dist::PGeometric(2, 0.5).evaluated(0, false), (1.0, 0.0));
+        assert_eq!(Dist::PGeometric(2, 0.5).evaluated(1, false), (1.0, 0.0));
+        assert_eq!(Dist::PGeometric(2, 0.5).evaluated(2, false), (0.5, 0.5));
     }
 
     #[test]
     fn test_distribution_binomial_degenerate() {
         // p = 0, the distribution is concentrated at 0
-        assert_eq!(Dist::PBinomial(0, 1.0).evaluate(0, false), (0.0, 1.0));
-        assert_eq!(Dist::PBinomial(0, 1.0).evaluate(1, false), (0.0, 0.0));
-        assert_eq!(Dist::PBinomial(0, 1.0).evaluate(2, false), (0.0, 0.0));
+        assert_eq!(Dist::PBinomial(0, 1.0).evaluated(0, false), (0.0, 1.0));
+        assert_eq!(Dist::PBinomial(0, 1.0).evaluated(1, false), (0.0, 0.0));
+        assert_eq!(Dist::PBinomial(0, 1.0).evaluated(2, false), (0.0, 0.0));
 
         // p = 1, the distribution is concentrated at n
-        assert_eq!(Dist::PBinomial(1, 1.0).evaluate(1, false), (0.0, 1.0));
-        assert_eq!(Dist::PBinomial(1, 1.0).evaluate(2, false), (0.0, 0.0));
-        assert_eq!(Dist::PBinomial(5, 1.0).evaluate(5, false), (0.0, 1.0));
+        assert_eq!(Dist::PBinomial(1, 1.0).evaluated(1, false), (0.0, 1.0));
+        assert_eq!(Dist::PBinomial(1, 1.0).evaluated(2, false), (0.0, 0.0));
+        assert_eq!(Dist::PBinomial(5, 1.0).evaluated(5, false), (0.0, 1.0));
     }
 
     #[test]
     fn test_distribution_binomial_up_to_1() {
-        assert_eq!(Dist::PBinomial(1, 0.5).evaluate(0, false), (0.5, 0.5));
-        assert_eq!(Dist::PBinomial(1, 0.5).evaluate(1, false), (0.5, 0.5));
-        assert_eq!(Dist::PBinomial(1, 0.5).evaluate(2, false), (0.0, 0.0));
+        assert_eq!(Dist::PBinomial(1, 0.5).evaluated(0, false), (0.5, 0.5));
+        assert_eq!(Dist::PBinomial(1, 0.5).evaluated(1, false), (0.5, 0.5));
+        assert_eq!(Dist::PBinomial(1, 0.5).evaluated(2, false), (0.0, 0.0));
     }
 
     #[test]
     fn test_distribution_binomial_up_to_2() {
         use Dist::PBinomial;
-        assert_eq!(PBinomial(2, 0.5).evaluate(0, false), (0.75, 0.25));
-        assert_eq!(PBinomial(2, 0.5).evaluate(1, false), (0.5, 0.5));
-        assert_eq!(PBinomial(2, 0.5).evaluate(2, false), (0.75, 0.25));
-        assert_eq!(PBinomial(2, 0.5).evaluate(3, false), (0.0, 0.0));
+        assert_eq!(PBinomial(2, 0.5).evaluated(0, false), (0.75, 0.25));
+        assert_eq!(PBinomial(2, 0.5).evaluated(1, false), (0.5, 0.5));
+        assert_eq!(PBinomial(2, 0.5).evaluated(2, false), (0.75, 0.25));
+        assert_eq!(PBinomial(2, 0.5).evaluated(3, false), (0.0, 0.0));
     }
 
     #[test]
     fn test_distribution_bernoulli() {
-        assert_eq!(Dist::PBernoulli(1, 0.5).evaluate(0, false), (0.5, 0.5));
-        assert_eq!(Dist::PBernoulli(1, 0.5).evaluate(1, false), (0.5, 0.5));
-        assert_eq!(Dist::PBernoulli(2, 0.5).evaluate(2, false), (1.0, 0.0));
+        assert_eq!(Dist::PBernoulli(1, 0.5).evaluated(0, false), (0.5, 0.5));
+        assert_eq!(Dist::PBernoulli(1, 0.5).evaluated(1, false), (0.5, 0.5));
+        assert_eq!(Dist::PBernoulli(2, 0.5).evaluated(2, false), (1.0, 0.0));
     }
 }

--- a/src/distribution.rs
+++ b/src/distribution.rs
@@ -73,7 +73,7 @@ impl Dist {
                 // named form, i.e. (a=0.0, b=0.1, c=0.2, ...)
                 Rule::NamedParam => {
                     let p_str = p.as_str();
-                    let (key, val) = p_str.trim().split_at(p_str.find("=").unwrap());
+                    let (key, val) = p_str.trim().split_at(p_str.find('=').unwrap());
                     (None, Some((key, &val[1..])))
                 }
                 _ => unreachable!(),
@@ -157,6 +157,7 @@ impl Dist {
                 true => return (p.ln(), p.ln()),
                 false => return (*p, *p),
             },
+            #[allow(clippy::comparison_chain)]
             Dist::ExactlyTimes(n_match) => {
                 let n = x.unwrap();
                 // does not depend on log

--- a/src/grammar.pest
+++ b/src/grammar.pest
@@ -29,7 +29,7 @@ QuantifierParam =  { ASCII_DIGIT* }
 
 Dist            =  { "~" ~ DistName ~ ( "(" ~ DistParams ~ ")" )? }
 DistName        =  { ^"Bin" | ^"Ber" | ^"Cat" | ^"Const" | ^"Geo" | ^"Zipf" }
-DistParams      = _{ DistParam ~ ("," ~ DistParam)? }
+DistParams      = _{ DistParam ~ ("," ~ DistParam)* }
 DistParam       = _{ IndexParam | NamedParam }
 IndexParam      =  { FLOAT_NUMBER }
 NamedParam      =  { ( Literal | Dot) ~ "=" ~ ( FLOAT_NUMBER | ASCII_DIGIT+ ) }

--- a/src/grammar.pest
+++ b/src/grammar.pest
@@ -12,7 +12,7 @@ Group           = _{ "(" ~ ( Alternation | Expression ) ~ ")" }
 Factor          = _{ Quantified | Group | Token }
 Token           = _{ Literal | Dot | Class }
 Quantified      =  { ( Token | Group ) ~ Quantifier }
-Literal         =  { ASCII_ALPHANUMERIC | " " }
+Literal         =  { ASCII_ALPHANUMERIC | " " | "-" }
 Dot             =  { "." }
 
 Class           = _{ ShortClass | LongClass }
@@ -32,7 +32,7 @@ DistName        =  { ^"Bin" | ^"Ber" | ^"Cat" | ^"Const" | ^"Geo" | ^"Zipf" }
 DistParams      = _{ DistParam ~ ("," ~ DistParam)? }
 DistParam       = _{ IndexParam | NamedParam }
 IndexParam      =  { FLOAT_NUMBER }
-NamedParam      =  { ASCII_ALPHA ~ "=" ~ ( FLOAT_NUMBER | ASCII_DIGIT+ ) }
+NamedParam      =  { ( Literal | Dot) ~ "=" ~ ( FLOAT_NUMBER | ASCII_DIGIT+ ) }
 
 
 FLOAT_NUMBER    = _{ ASCII_DIGIT+ ~ "." ~ ASCII_DIGIT+ }

--- a/src/grammar.pest
+++ b/src/grammar.pest
@@ -28,7 +28,7 @@ ExactQuantifier =  { QuantifierParam }
 QuantifierParam =  { ASCII_DIGIT* }
 
 Dist            =  { "~" ~ DistName ~ ( "(" ~ DistParams ~ ")" )? }
-DistName        =  { ^"Geo" | ^"Bin" | ^"Ber" | ^"Const" | ^"Zipf" }
+DistName        =  { ^"Bin" | ^"Ber" | ^"Cat" | ^"Const" | ^"Geo" | ^"Zipf" }
 DistParams      = _{ DistParam ~ ("," ~ DistParam)? }
 DistParam       = _{ IndexParam | NamedParam }
 IndexParam      =  { FLOAT_NUMBER }

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,8 +28,7 @@ pub type Result<T> = ::std::result::Result<T, Box<dyn Error>>;
 fn main() -> Result<()> {
     let config = Config::parse();
     env_logger::init();
-    let asts = parser::parse(&config.pattern)?;
-    let nfa = nfa::asts_to_nfa(asts);
+    let nfa = compile(&config.pattern)?;
     let reader = input_reader(&config)?;
 
     for line in reader.lines() {
@@ -43,6 +42,10 @@ fn main() -> Result<()> {
     }
 
     Ok(())
+}
+
+pub fn compile(source: &str) -> Result<Vec<nfa::State>> {
+    Ok(nfa::asts_to_nfa(parser::parse(source)?))
 }
 
 /// Get input reader based on config

--- a/src/nfa.rs
+++ b/src/nfa.rs
@@ -66,6 +66,14 @@ impl State {
             dist: None,
         }
     }
+    #[allow(dead_code)]
+    pub fn dot(outs: Outs) -> State {
+        State {
+            kind: Kind::Dot,
+            outs,
+            dist: None,
+        }
+    }
 }
 
 type Outs = (Option<usize>, Option<usize>);

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -27,7 +27,7 @@ pub fn parse(source: &str) -> std::result::Result<Vec<AstNode>, pest::error::Err
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::distribution::Dist;
+    use crate::distribution::{Dist, DistLink};
 
     fn ast_as_str(asts: Vec<AstNode>) -> String {
         asts.into_iter()
@@ -153,7 +153,7 @@ mod test {
                         length: 1,
                         kind: Kind::Literal('a'),
                     }),
-                    Some(Dist::ExactlyTimes(2)),
+                    Some(Dist::ExactlyTimes(2).count()),
                 ),
             },
             AstNode {
@@ -179,7 +179,7 @@ mod test {
                         length: 1,
                         kind: Kind::Literal('a'),
                     }),
-                    Some(Dist::PGeometric(2, 0.5)),
+                    Some(Dist::PGeometric(2, 0.5).count()),
                 ),
             },
             AstNode {
@@ -207,7 +207,7 @@ mod test {
     }
 
     #[test]
-    fn test_parser_exact_class_dist_ast() {
+    fn test_parser_exact_class_indexed_dist_ast() {
         let result = parse("[abc~Geo(0.5)]").unwrap_or_default();
         let expected = vec![
             AstNode {
@@ -217,7 +217,7 @@ mod test {
                         length: 1,
                         kind: Kind::Class(vec!['a', 'b', 'c']),
                     }),
-                    Some(Dist::PGeometric(0, 0.5)),
+                    Some(Dist::PGeometric(0, 0.5).index()),
                 ),
             },
             AstNode {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -229,6 +229,177 @@ mod test {
     }
 
     #[test]
+    fn test_parser_exact_class_named_dist_ast() {
+        let result = parse("[ab~Cat(a=0.7,b=0.2)]").unwrap_or_default();
+        let expected = vec![
+            AstNode {
+                length: 1,
+                kind: Kind::Classified(
+                    Box::new(AstNode {
+                        length: 1,
+                        kind: Kind::Class(vec!['a', 'b']),
+                    }),
+                    Some(Dist::Categorical(vec![0.10000000000000009, 0.7, 0.2]).index()),
+                ),
+            },
+            AstNode {
+                length: 0,
+                kind: Kind::Terminal,
+            },
+        ];
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_parser_exact_class_named_dist_rest_ast() {
+        let result = parse("[abc~Cat(a=0.7)]").unwrap_or_default();
+        let expected = vec![
+            AstNode {
+                length: 1,
+                kind: Kind::Classified(
+                    Box::new(AstNode {
+                        length: 1,
+                        kind: Kind::Class(vec!['a', 'b', 'c']),
+                    }),
+                    Some(
+                        Dist::Categorical(vec![0.0, 0.7, 0.15000000000000002, 0.15000000000000002])
+                            .index(),
+                    ),
+                ),
+            },
+            AstNode {
+                length: 0,
+                kind: Kind::Terminal,
+            },
+        ];
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_parser_exact_class_named_class_dist_ast() {
+        let result = parse("[\\d~Cat(1=0.7,2=0.3)]").unwrap_or_default();
+        let expected = vec![
+            AstNode {
+                length: 1,
+                kind: Kind::Classified(
+                    Box::new(AstNode {
+                        length: 1,
+                        kind: Kind::Class(vec!['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']),
+                    }),
+                    Some(
+                        Dist::Categorical(vec![
+                            0.0, 0.0, 0.7, 0.3, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+                        ])
+                        .index(),
+                    ),
+                ),
+            },
+            AstNode {
+                length: 0,
+                kind: Kind::Terminal,
+            },
+        ];
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_parser_exact_class_named_dot_ast() {
+        let result = parse("[ab~Cat(a=0.7,.=0.1)]").unwrap_or_default();
+        let expected = vec![
+            AstNode {
+                length: 1,
+                kind: Kind::Classified(
+                    Box::new(AstNode {
+                        length: 1,
+                        kind: Kind::Class(vec!['a', 'b']),
+                    }),
+                    Some(Dist::Categorical(vec![0.1, 0.7, 0.20000000000000007]).index()),
+                ),
+            },
+            AstNode {
+                length: 0,
+                kind: Kind::Terminal,
+            },
+        ];
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_parser_exact_class_named_class_dot_ast() {
+        let result = parse("[\\d~Cat(0=0.6,.=0.175)]").unwrap_or_default();
+        let expected = vec![
+            AstNode {
+                length: 1,
+                kind: Kind::Classified(
+                    Box::new(AstNode {
+                        length: 1,
+                        kind: Kind::Class(vec!['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']),
+                    }),
+                    Some(
+                        Dist::Categorical(vec![
+                            0.175,
+                            0.6,
+                            // remaining digits have 0.225 / 9 = 0.025
+                            0.02500000000000001,
+                            0.02500000000000001,
+                            0.02500000000000001,
+                            0.02500000000000001,
+                            0.02500000000000001,
+                            0.02500000000000001,
+                            0.02500000000000001,
+                            0.02500000000000001,
+                            0.02500000000000001,
+                        ])
+                        .index(),
+                    ),
+                ),
+            },
+            AstNode {
+                length: 0,
+                kind: Kind::Terminal,
+            },
+        ];
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_parser_exact_class_named_dist_rest_zero_ast() {
+        let result = parse("^[\\d~Cat(1=0.9,.=0.1)]$").unwrap_or_default();
+        let expected = vec![
+            AstNode {
+                length: 0,
+                kind: Kind::AnchorStart,
+            },
+            AstNode {
+                length: 1,
+                kind: Kind::Classified(
+                    Box::new(AstNode {
+                        length: 1,
+                        kind: Kind::Class(vec!['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']),
+                    }),
+                    Some(
+                        Dist::Categorical(vec![
+                            0.1, 0.0, 0.9,
+                            // these are zero because 0.1 reserved for other than named params
+                            0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+                        ])
+                        .index(),
+                    ),
+                ),
+            },
+            AstNode {
+                length: 1,
+                kind: Kind::AnchorEnd,
+            },
+            AstNode {
+                length: 0,
+                kind: Kind::Terminal,
+            },
+        ];
+        assert_eq!(result, expected);
+    }
+
+    #[test]
     fn test_parser_short_class_ast() {
         let result = parse("\\d").unwrap_or_default();
         let expected = vec![

--- a/src/regex.rs
+++ b/src/regex.rs
@@ -140,7 +140,7 @@ mod test {
             State::new(
                 Kind::ExactQuantifier(2),
                 (Some(1), Some(3)),
-                Some(Dist::ExactlyTimes(2)),
+                Some(Dist::ExactlyTimes(2).count()),
             ),
             State::literal('b', (Some(4), None)),
             State::terminal(),
@@ -171,7 +171,7 @@ mod test {
             State::new(
                 Kind::ExactQuantifier(2),
                 (Some(1), Some(3)),
-                Some(Dist::PGeometric(2, 0.5)),
+                Some(Dist::PGeometric(2, 0.5).count()),
             ),
             State::literal('b', (Some(4), None)),
             State::terminal(),

--- a/src/regex.rs
+++ b/src/regex.rs
@@ -40,6 +40,9 @@ fn step_states(
         let transitions = evaluate_state(state, token, *p, nfa, counts, &states, false);
         for transition in transitions {
             if let Transition(Some(out), new_p) = transition {
+                if new_p == 0.0 {
+                    continue;
+                }
                 let old_p = next.entry(out).or_insert(new_p);
                 *old_p = f64::max(*old_p, new_p);
             }
@@ -151,7 +154,7 @@ mod test {
         let counts = add_counts(&states, &HashMap::new());
         assert_eq!(counts, [(1, 1)].into());
         let states = step_states(states, &counts, &Kind::Literal('a'), &nfa);
-        assert_eq!(states, [(1, 1.0), (2, 1.0), (3, 0.0)].into());
+        assert_eq!(states, [(1, 1.0), (2, 1.0)].into());
 
         let counts = add_counts(&states, &counts);
         assert_eq!(counts, [(1, 2), (2, 1)].into());
@@ -182,7 +185,7 @@ mod test {
 
         let states = step_states(states, &counts, &Kind::Literal('a'), &nfa);
         let counts = add_counts(&states, &counts);
-        assert_eq!(states, [(1, 1.0), (2, 1.0), (3, 0.0)].into());
+        assert_eq!(states, [(1, 1.0), (2, 1.0)].into());
 
         let states = step_states(states, &counts, &Kind::Literal('a'), &nfa);
         let counts = add_counts(&states, &counts);

--- a/src/regex_state.rs
+++ b/src/regex_state.rs
@@ -114,6 +114,13 @@ pub fn evaluate_state(
                 ]
                 .concat();
             }
+            Kind::Dot => {
+                if is_epsilon {
+                    return vec![Transition(Some(idx), p)];
+                }
+
+                return evaluate_state_outs(state.outs, token, p, nfa, counts, states, true);
+            }
             Kind::Literal(match_c) => {
                 if is_epsilon {
                     return vec![Transition(Some(idx), p)];
@@ -230,6 +237,40 @@ mod test {
             State::start(Some(1)),
             State::literal('a', (Some(2), None)),
             State::literal('b', (Some(3), None)),
+            State::terminal(),
+        ];
+        let counts: HashMap<usize, u64> = HashMap::new();
+        let states: HashMap<usize, f64> = HashMap::new();
+
+        let transitions = evaluate_state(
+            Some(1),
+            &Kind::Literal('a'),
+            1.0,
+            &nfa,
+            &counts,
+            &states,
+            false,
+        );
+        assert_eq!(transitions, vec![Transition(Some(2), 1.0)]);
+
+        let transitions = evaluate_state(
+            Some(1),
+            &Kind::Literal('b'),
+            1.0,
+            &nfa,
+            &counts,
+            &states,
+            false,
+        );
+        assert_eq!(transitions, vec![]);
+    }
+
+    #[test]
+    fn test_evaluate_state_dot() {
+        let nfa = vec![
+            State::start(Some(1)),
+            State::literal('a', (Some(2), None)),
+            State::dot((Some(3), None)),
             State::terminal(),
         ];
         let counts: HashMap<usize, u64> = HashMap::new();

--- a/src/regex_state.rs
+++ b/src/regex_state.rs
@@ -33,7 +33,7 @@ pub fn initial_state(nfa: &Vec<State>, skip_start: bool) -> HashMap<usize, f64> 
 pub fn terminal_state_p(states: &HashMap<usize, f64>, nfa: &Vec<State>) -> Option<f64> {
     // TODO may not be the terminal state
     let idx_terminal = nfa.len() - 1;
-    states.get(&idx_terminal).and_then(|p| Some(*p))
+    states.get(&idx_terminal).map(|p| *p)
 }
 
 /// Evaluate the state idx against token, return transitions to next states
@@ -88,7 +88,7 @@ pub fn evaluate_state(
                 }
             }
             Kind::Split => {
-                return evaluate_state_outs(state.outs, token, p, nfa, &counts, states, true);
+                return evaluate_state_outs(state.outs, token, p, nfa, counts, states, true);
             }
             Kind::Quantifier(_) | Kind::ExactQuantifier(_) => {
                 if !is_epsilon {

--- a/src/regex_state.rs
+++ b/src/regex_state.rs
@@ -127,16 +127,24 @@ pub fn evaluate_state(
                     }
                 }
             }
-            Kind::Class(_) => {
+            Kind::Class(ref match_c) => {
                 if is_epsilon {
                     return vec![Transition(Some(idx), p)];
                 }
 
-                let (_, p1) = match &state.dist {
-                    Some(dist) => dist.pmf_link(token, 0, &state.kind, false),
-                    None => (1., 1.),
-                };
-                return evaluate_state(state.outs.0, token, p * p1, nfa, counts, states, true);
+                if let Kind::Literal(c) = token {
+                    let idx = match match_c.iter().position(|&r| r == *c) {
+                        Some(i) => i as u64,
+                        None => return vec![],
+                    };
+                    let (_, p1) = match &state.dist {
+                        Some(dist) => dist.pmf_link(token, idx, &state.kind, false),
+                        None => (1., 1.),
+                    };
+
+                    return evaluate_state(state.outs.0, token, p * p1, nfa, counts, states, true);
+                }
+                return vec![];
             }
             _ => {}
         }


### PR DESCRIPTION
Implement categorical distribution.
* Add categorical distribution `~Cat(a=0.5)`
* Get rid of mapped distributions, and make Zipf indexed instead. This makes it possible to use
* fix bug in `.` matching

Examples
```
$ pregex "^[\d~Cat(1=0.9)]{2}$" 10
0.01000 10
# which is 0.9 * (0.1/9), where the latter is the remaining mass of 0.1 divided among the remaining digits
$ pregex  "^[eta~Cat(e=0.13,t=0.09,a=0.08)]$" "a"
0.08000 a
```