### PR TITLE
Distribution fixes

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -38,10 +38,8 @@ impl fmt::Display for Kind {
                 true => write!(f, "[{}..]", c.iter().take(3).join("")),
                 false => write!(f, "[{}]", c.iter().join("")),
             },
-            Kind::Classified(l, d) => match d {
-                Some(d) => write!(f, "[{}{}]", l, d),
-                None => write!(f, "[{}]", l),
-            },
+            Kind::Classified(l, Some(d)) => write!(f, "[{}{}]", l, d),
+            Kind::Classified(l, None) => write!(f, "[{}]", l),
             Kind::Concatenation(l, r) => write!(f, "{}{}.", l, r),
             Kind::Quantified(r, l, Some(d)) => write!(f, "{}{{{}{}}}", l, r, d),
             Kind::Quantified(r, l, None) => match r.kind {
@@ -117,7 +115,7 @@ pub fn build_ast_from_expr(pair: Pair<Rule>) -> AstNode {
                 kind: Kind::Quantified(
                     Box::new(quantifier_ast),
                     Box::new(left_ast),
-                    quantifier_dist.map(|d| DistLink::Counted(d)),
+                    quantifier_dist.map(DistLink::Counted),
                 ),
             }
         }
@@ -173,8 +171,7 @@ pub fn build_ast_from_expr(pair: Pair<Rule>) -> AstNode {
         }
         Rule::ExactQuantifier => {
             let pair = pair.into_inner().next().unwrap();
-            // uses str::parse to convert to appropriate Rust type
-            let n: u64 = pair.as_str().parse().unwrap();
+            let n = pair.as_str().parse::<u64>().unwrap();
             AstNode {
                 length: 1,
                 kind: Kind::ExactQuantifier(n),

--- a/src/distribution.rs
+++ b/src/distribution.rs
@@ -134,7 +134,10 @@ impl Dist {
             }
             "zipf" => {
                 let p: f64 = params.first().unwrap_or(&"1.0").parse().unwrap();
-                let n = c.expect("chars to be passed").len() as u64;
+                let n = match c {
+                    Some(c) => c.len() as u64,
+                    None => n,
+                };
                 Dist::PZipf(0, n, p)
             }
             _ => {

--- a/src/distribution.rs
+++ b/src/distribution.rs
@@ -44,24 +44,21 @@ impl Dist {
         }
     }
 
-    /// Distribution from quantifier kind and distribution params
+    /// Distribution from kind and distribution params
     ///
     /// Eg. complete_from(ExactQuantifier(2), Dist::Normal(sigma))
     /// would return a Normal distribution centered at 2.
-    pub fn complete_from(
-        quantifier_kind: &Kind,
-        quantifier_dist_pair: Pair<'_, crate::parser::Rule>,
-    ) -> Self {
-        let n = match quantifier_kind {
+    pub fn complete_from(kind: &Kind, dist_pair: Pair<'_, crate::parser::Rule>) -> Self {
+        let n = match kind {
             Kind::ExactQuantifier(n) => *n,
             _ => 0, // required n is zero
         };
-        let c = match quantifier_kind {
+        let c = match kind {
             Kind::Class(c) => Some(c),
             _ => None,
         };
 
-        let mut pair = quantifier_dist_pair.into_inner();
+        let mut pair = dist_pair.into_inner();
         let name = pair.next().unwrap().as_span().as_str().to_lowercase();
 
         // Parse parameters, that may be supplied in various formats

--- a/src/distribution.rs
+++ b/src/distribution.rs
@@ -248,9 +248,15 @@ impl Dist {
 }
 
 /// Calculates the probability mass function for the zipf distribution at `x`
-fn zipf(x: u64, s: f64, n_max: u64) -> f64 {
-    let normalizer: f64 = (1..(n_max + 1)).map(|n_i| 1.0 / (n_i as f64).powf(s)).sum();
-    (1.0 / (x as f64).powf(s)) / normalizer
+fn zipf(x: u64, a: f64, n: u64) -> f64 {
+    assert!(x > 0, "outside zipf distribution support");
+
+    let normalizer = generalized_harmonic_number(n, a);
+    (1.0 / (x as f64).powf(a)) / normalizer
+}
+
+fn generalized_harmonic_number(n: u64, m: f64) -> f64 {
+    (1..(n + 1)).map(|n_i| 1.0 / (n_i as f64).powf(m)).sum()
 }
 
 /// Link for mapping state parameters to distribution parameters

--- a/src/distribution.rs
+++ b/src/distribution.rs
@@ -155,7 +155,7 @@ impl Dist {
     }
 
     /// Test helper
-    pub fn evaluated(&self, x: u64, log: bool) -> (f64, f64) {
+    pub(crate) fn evaluated(&self, x: u64, log: bool) -> (f64, f64) {
         self.evaluate(Some(x), log)
     }
 
@@ -390,5 +390,29 @@ mod test {
         assert_eq!(Dist::PBernoulli(0, 1, 0.5).evaluated(0, false), (0.5, 0.5));
         assert_eq!(Dist::PBernoulli(0, 1, 0.5).evaluated(1, false), (0.5, 0.5));
         assert_eq!(Dist::PBernoulli(0, 2, 0.5).evaluated(2, false), (1.0, 0.0));
+    }
+
+    #[test]
+    fn test_distribution_categorical() {
+        let dist = Dist::Categorical(vec![0.5, 0.3, 0.2]);
+
+        assert_eq!(dist.evaluated(0, false), (0.5, 0.5));
+        assert_eq!(dist.evaluated(1, false), (0.7, 0.3));
+        assert_eq!(dist.evaluated(2, false), (0.8, 0.2));
+        assert_eq!(dist.evaluated(3, false), (1.0, 0.0));
+    }
+
+    #[test]
+    #[rustfmt::skip]
+    fn test_distribution_zipf() {
+        // n_max = 1, the normalizing constant is 1
+        let dist = Dist::PZipf(0, 1, 1.0);
+        assert_eq!(dist.evaluated(1, false), (1. - (1. / 1.), (1. / 1.)));
+        assert_eq!(dist.evaluated(2, false), (1. - (1. / 2.), (1. / 2.)));
+
+        // n_max = 2, the normalizing constant is 3/2 = 1.5
+        let dist = Dist::PZipf(0, 2, 1.0);
+        assert_eq!(dist.evaluated(1, false), (1. - (1. / 1.) / 1.5, (1. / 1.) / 1.5));
+        assert_eq!(dist.evaluated(2, false), (1. - (1. / 2.) / 1.5, (1. / 2.) / 1.5));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,18 +103,13 @@ mod test {
     }
 
     #[test]
+    #[rustfmt::skip]
     fn test_quantifier_exact() {
         let nfa = compile("^a{5~Geo(0.5)}$").unwrap();
 
         assert_eq!(match_likelihood(&nfa, &"aaaa".to_string(), false), None);
-        assert_eq!(
-            match_likelihood(&nfa, &"aaaaa".to_string(), false),
-            Some(0.5)
-        );
-        assert_eq!(
-            match_likelihood(&nfa, &"aaaaaa".to_string(), false),
-            Some(0.25)
-        );
+        assert_eq!(match_likelihood(&nfa, &"aaaaa".to_string(), false), Some(0.5));
+        assert_eq!(match_likelihood(&nfa, &"aaaaaa".to_string(), false), Some(0.25));
     }
 
     #[test]
@@ -122,25 +117,45 @@ mod test {
     fn test_quantifier_zipf() {
         let nfa = compile("^a{2~Zipf(1.0)}$").unwrap();
         let harmonic_number_2 = 3. / 2.;
-        assert_eq!(match_likelihood(&nfa, &"a".to_string(), false), Some((1. / 2.) / harmonic_number_2));
-        assert_eq!(match_likelihood(&nfa, &"aa".to_string(), false), Some((1. / 3.) / harmonic_number_2));
-        assert_eq!(match_likelihood(&nfa, &"aaa".to_string(), false), Some((1. / 4.) / harmonic_number_2));
+        assert_eq!(match_likelihood(&nfa, &"a".to_string(), false), Some((1. / 1.) / harmonic_number_2));
+        assert_eq!(match_likelihood(&nfa, &"aa".to_string(), false), Some((1. / 2.) / harmonic_number_2));
+        assert_eq!(match_likelihood(&nfa, &"aaa".to_string(), false), Some((1. / 3.) / harmonic_number_2));
     }
 
     #[test]
     #[rustfmt::skip]
     fn test_class_zipf() {
         // n = 2, 1st is 2/3 and the 2nd is 1/3
+        // s = 1.0, normalizer is the (non-generalized) harmonic number
         let nfa = compile("^[ab~Zipf(1.0)]$").unwrap();
         let harmonic_number_2 = 3. / 2.;
         assert_eq!(match_likelihood(&nfa, &"a".to_string(), false), Some((1. / 1.) / harmonic_number_2));
         assert_eq!(match_likelihood(&nfa, &"b".to_string(), false), Some((1. / 2.) / harmonic_number_2));
+        assert_eq!(match_likelihood(&nfa, &"c".to_string(), false), None);
+    }
 
-        // n = 26, the canonical english alphabet case
-        let nfa = compile("^[etaoinshrdlcumwfgypbvkjxqz~Zipf(0.6)]$").unwrap();
-        let harmonic_number_26 = 34395742267. / 8923714800.;
-        assert_relative_eq!(match_likelihood(&nfa, &"e".to_string(), false).unwrap(), (1. / 2.) / harmonic_number_26, epsilon = 0.01);
-        assert_relative_eq!(match_likelihood(&nfa, &"t".to_string(), false).unwrap(), (1. / 3.) / harmonic_number_26, epsilon = 0.01);
+    #[test]
+    fn test_class_geo() {
+        let nfa = compile("^[abc~Geo(0.5)]$").unwrap();
+        assert_eq!(match_likelihood(&nfa, &"a".to_string(), false), Some(0.5));
+        assert_eq!(match_likelihood(&nfa, &"b".to_string(), false), Some(0.25));
+        assert_eq!(match_likelihood(&nfa, &"c".to_string(), false), Some(0.125));
+    }
+
+    #[test]
+    fn test_class_ber() {
+        let nfa = compile("^[abc~Ber(0.5)]$").unwrap();
+        assert_eq!(match_likelihood(&nfa, &"a".to_string(), false), Some(0.5));
+        assert_eq!(match_likelihood(&nfa, &"b".to_string(), false), Some(0.5));
+        assert_eq!(match_likelihood(&nfa, &"c".to_string(), false), None);
+    }
+
+    #[test]
+    fn test_class_bin() {
+        let nfa = compile("^[abc~Bin(0.5)]$").unwrap();
+        assert_eq!(match_likelihood(&nfa, &"a".to_string(), false), Some(0.25));
+        assert_eq!(match_likelihood(&nfa, &"b".to_string(), false), Some(0.5));
+        assert_eq!(match_likelihood(&nfa, &"c".to_string(), false), Some(0.25));
     }
 
     #[test]

--- a/src/nfa.rs
+++ b/src/nfa.rs
@@ -694,7 +694,7 @@ mod test {
                                 length: 1,
                                 kind: Kind::Literal('b'),
                             }),
-                            Some(Dist::PGeometric(2, 0.5).count()),
+                            Some(Dist::PGeometric(2, u64::MAX, 0.5).count()),
                         ),
                     }),
                 ),
@@ -720,7 +720,7 @@ mod test {
             State::new(
                 Kind::ExactQuantifier(2),
                 (Some(1), Some(3)),
-                Some(Dist::PGeometric(2, 0.5).count()),
+                Some(Dist::PGeometric(2, u64::MAX, 0.5).count()),
             ),
         ];
         assert_eq!(result, expected);
@@ -762,7 +762,7 @@ mod test {
                         length: 1,
                         kind: Kind::Class(vec!['a', 'b', 'c']),
                     }),
-                    Some(Dist::PGeometric(0, 0.5).count()),
+                    Some(Dist::PGeometric(0, u64::MAX, 0.5).count()),
                 ),
             },
             0,
@@ -771,7 +771,7 @@ mod test {
         let expected = vec![State::new(
             Kind::Class(vec!['a', 'b', 'c']),
             (Some(1), None),
-            Some(Dist::PGeometric(0, 0.5).count()),
+            Some(Dist::PGeometric(0, u64::MAX, 0.5).count()),
         )];
         assert_eq!(result, expected);
     }

--- a/src/nfa.rs
+++ b/src/nfa.rs
@@ -219,9 +219,6 @@ fn ast_to_frag(ast: AstNode, index: usize, outs: Outs, distribution: Option<Dist
             start: index,
             outs,
         },
-        _ => {
-            panic!("{} is not allowed in the AST", ast.kind.to_string());
-        }
     }
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -179,7 +179,7 @@ mod test {
                         length: 1,
                         kind: Kind::Literal('a'),
                     }),
-                    Some(Dist::PGeometric(2, 0.5).count()),
+                    Some(Dist::PGeometric(2, u64::MAX, 0.5).count()),
                 ),
             },
             AstNode {
@@ -217,7 +217,7 @@ mod test {
                         length: 1,
                         kind: Kind::Class(vec!['a', 'b', 'c']),
                     }),
-                    Some(Dist::PGeometric(0, 0.5).index()),
+                    Some(Dist::PGeometric(0, u64::MAX, 0.5).index()),
                 ),
             },
             AstNode {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -539,5 +539,6 @@ mod test {
     #[test]
     fn test_parser_exact_class_with_dist() {
         assert_eq!(ast_as_str(parse("[ab~Const]").unwrap()), "[[ab]]");
+        assert_eq!(ast_as_str(parse("[ab~Geo(1.0)]").unwrap()), "[[ab]~Geo(1)]");
     }
 }

--- a/src/regex.rs
+++ b/src/regex.rs
@@ -174,7 +174,7 @@ mod test {
             State::new(
                 Kind::ExactQuantifier(2),
                 (Some(1), Some(3)),
-                Some(Dist::PGeometric(2, 0.5).count()),
+                Some(Dist::PGeometric(2, u64::MAX, 0.5).count()),
             ),
             State::literal('b', (Some(4), None)),
             State::terminal(),

--- a/src/regex_state.rs
+++ b/src/regex_state.rs
@@ -307,7 +307,7 @@ mod test {
             State::new(
                 Kind::ExactQuantifier(2),
                 (Some(1), Some(3)),
-                Some(DistLink::Counted(Dist::PGeometric(2, 0.5))),
+                Some(DistLink::Counted(Dist::PGeometric(2, u64::MAX, 0.5))),
             ),
             State::literal('b', (Some(4), None)),
             State::terminal(),
@@ -361,7 +361,7 @@ mod test {
             State::new(
                 Kind::Class(vec!['a', 'b', 'c']),
                 (Some(2), None),
-                Some(DistLink::Indexed(Dist::PGeometric(0, 0.5))),
+                Some(DistLink::Indexed(Dist::PGeometric(0, u64::MAX, 0.5))),
             ),
             State::terminal(),
         ];


### PR DESCRIPTION
Fix some distributions.
* Introduce `(n_min, n_max)` tuple for most distributions (useful for for future quantifier ranges). This is now hardcoded as distribution specific, eg.
  * `{3~Geo}` sets `n_min` 3
  * `{3~Zipf}` sets `n_max` 3
  * ...etc.
 * move and hardcode some `+1` offsets to `DistributionLink` to fix distributions (eg. categorical and zipf). This should be handled by regarding the [support](https://en.wikipedia.org/wiki/Support_(mathematics)) for the distributions.
 * naming and cleanup
 * tests