### PR TITLE
Zero quantifier

### DIFF
--- a/src/distribution.rs
+++ b/src/distribution.rs
@@ -254,8 +254,12 @@ impl Dist {
 }
 
 /// Calculates the probability mass function for the zipf distribution at `x`
+// The Zipf distribution reduces to the Zeta distribution as n -> inf
 fn zipf(x: u64, a: f64, n: u64) -> f64 {
-    assert!(x > 0, "outside zipf distribution support");
+    // Support zero for consistency
+    if x == 0 {
+        return 0.0;
+    }
 
     let normalizer = generalized_harmonic_number(n, a);
     (1.0 / (x as f64).powf(a)) / normalizer

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,9 +33,7 @@ fn main() -> Result<()> {
 
     for line in reader.lines() {
         match line {
-            // TODO move debug visualize here, and use match_likelihood_stats or soething to get state out?
             Ok(input) => match regex::match_likelihood(&nfa, &input, config.visualize) {
-                // Some(p) => println!("{:.5}\t{}", p, input),
                 Some(p) => println!("{:.5}\t{}", p, input),
                 None => {}
             },
@@ -104,7 +102,7 @@ mod test {
 
     #[test]
     #[rustfmt::skip]
-    fn test_quantifier_exact() {
+    fn test_quantifier_geo() {
         let nfa = compile("^a{5~Geo(0.5)}$").unwrap();
 
         assert_eq!(match_likelihood(&nfa, &"aaaa".to_string(), false), None);

--- a/src/main.rs
+++ b/src/main.rs
@@ -101,6 +101,29 @@ mod test {
     }
 
     #[test]
+    fn test_quantifier_zero() {
+        let nfa = compile("^ab{0}$").unwrap();
+
+        assert_eq!(match_likelihood(&nfa, &"a".to_string(), false), Some(1.0));
+        assert_eq!(match_likelihood(&nfa, &"ab".to_string(), false), None);
+        assert_eq!(match_likelihood(&nfa, &"aa".to_string(), false), None);
+    }
+
+    #[test]
+    fn test_quantifier_zero_constant() {
+        let nfa = compile("^ab{0~Const(0.5)}$").unwrap();
+
+        assert_eq!(match_likelihood(&nfa, &"a".to_string(), false), Some(0.5));
+        assert_eq!(match_likelihood(&nfa, &"ab".to_string(), false), None);
+        assert_eq!(match_likelihood(&nfa, &"aa".to_string(), false), None);
+
+        let nfa = compile("^a\\d{0~Const(0.5)}$").unwrap();
+
+        assert_eq!(match_likelihood(&nfa, &"a".to_string(), false), Some(0.5));
+        assert_eq!(match_likelihood(&nfa, &"a0".to_string(), false), None);
+    }
+
+    #[test]
     #[rustfmt::skip]
     fn test_quantifier_geo() {
         let nfa = compile("^a{5~Geo(0.5)}$").unwrap();

--- a/src/nfa.rs
+++ b/src/nfa.rs
@@ -486,7 +486,7 @@ mod test {
     }
 
     #[test]
-    fn test_compile_star() {
+    fn test_compile_quantifier_star() {
         let result = ast_to_nfa(
             AstNode {
                 length: 3,
@@ -529,7 +529,7 @@ mod test {
     }
 
     #[test]
-    fn test_compile_plus() {
+    fn test_compile_quantifier_plus() {
         let result = ast_to_nfa(
             AstNode {
                 length: 3,
@@ -572,7 +572,7 @@ mod test {
     }
 
     #[test]
-    fn test_compile_exact_quantifier() {
+    fn test_compile_quantifier_exact() {
         let result = ast_to_nfa(
             AstNode {
                 length: 3,
@@ -613,7 +613,7 @@ mod test {
     }
 
     #[test]
-    fn test_compile_exact_quantifier_dist() {
+    fn test_compile_quantifier_exact_dist() {
         let result = ast_to_nfa(
             AstNode {
                 length: 3,

--- a/src/nfa.rs
+++ b/src/nfa.rs
@@ -453,7 +453,7 @@ mod test {
                         kind: Kind::Literal('a'),
                     }),
                     Box::new(AstNode {
-                        length: 1,
+                        length: 2,
                         kind: Kind::Quantified(
                             Box::new(AstNode {
                                 length: 1,
@@ -496,7 +496,7 @@ mod test {
                         kind: Kind::Literal('a'),
                     }),
                     Box::new(AstNode {
-                        length: 1,
+                        length: 2,
                         kind: Kind::Quantified(
                             Box::new(AstNode {
                                 length: 1,
@@ -539,7 +539,7 @@ mod test {
                         kind: Kind::Literal('a'),
                     }),
                     Box::new(AstNode {
-                        length: 1,
+                        length: 2,
                         kind: Kind::Quantified(
                             Box::new(AstNode {
                                 length: 1,
@@ -582,7 +582,7 @@ mod test {
                         kind: Kind::Literal('a'),
                     }),
                     Box::new(AstNode {
-                        length: 1,
+                        length: 2,
                         kind: Kind::Quantified(
                             Box::new(AstNode {
                                 length: 1,
@@ -623,7 +623,7 @@ mod test {
                         kind: Kind::Literal('a'),
                     }),
                     Box::new(AstNode {
-                        length: 1,
+                        length: 2,
                         kind: Kind::Quantified(
                             Box::new(AstNode {
                                 length: 1,
@@ -778,7 +778,7 @@ mod test {
                     kind: Kind::Literal('a'),
                 }),
                 Box::new(AstNode {
-                    length: 1,
+                    length: 2,
                     kind: Kind::Quantified(
                         Box::new(AstNode {
                             length: 1,

--- a/src/nfa.rs
+++ b/src/nfa.rs
@@ -921,6 +921,25 @@ mod test {
 
     #[test]
     fn test_asts_to_nfa_start_node_special_case_2() {
+        let asts = parse("ab{0}c").unwrap();
+        let result = asts_to_nfa(asts);
+        let expected = vec![
+            State::start(Some(1)),
+            State::literal('a', (Some(2), None)),
+            State {
+                kind: Kind::ExactQuantifier(0),
+                outs: (Some(3), Some(4)),
+                dist: Some(Dist::ExactlyTimes(0).count()),
+            },
+            State::literal('b', (Some(2), None)),
+            State::literal('c', (Some(5), None)),
+            State::terminal(),
+        ];
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_asts_to_nfa_start_node_special_case_3() {
         let asts = parse("a?b").unwrap();
         let result = asts_to_nfa(asts);
         let expected = vec![
@@ -940,7 +959,7 @@ mod test {
     }
 
     #[test]
-    fn test_nfas_to_ast_start_node_special_case_3() {
+    fn test_nfas_to_ast_start_node_special_case_4() {
         let asts = parse("a{2}b").unwrap();
         let result = asts_to_nfa(asts);
         let expected = vec![

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -191,6 +191,33 @@ mod test {
     }
 
     #[test]
+    fn test_parser_exact_zero_quantifier_dist_ast() {
+        let result = parse("a{0~Const}").unwrap_or_default();
+        let expected = vec![
+            AstNode {
+                length: 2,
+                kind: Kind::Quantified(
+                    Box::new(AstNode {
+                        length: 1,
+                        kind: Kind::ExactQuantifier(0),
+                    }),
+                    Box::new(AstNode {
+                        length: 1,
+                        kind: Kind::Literal('a'),
+                    }),
+                    // TODO maybe have n?min and n?max here
+                    Some(Dist::Constant(0, 0, 1.0).count()),
+                ),
+            },
+            AstNode {
+                length: 0,
+                kind: Kind::Terminal,
+            },
+        ];
+        assert_eq!(result, expected);
+    }
+
+    #[test]
     fn test_parser_exact_class_ast() {
         let result = parse("[abc]").unwrap_or_default();
         let expected = vec![

--- a/src/regex.rs
+++ b/src/regex.rs
@@ -139,25 +139,25 @@ mod test {
     fn test_step_states_exact_quantifier() {
         let nfa = vec![
             State::anchor_start(Some(1)),
-            State::literal('a', (Some(2), None)),
             State::new(
                 Kind::ExactQuantifier(2),
-                (Some(1), Some(3)),
+                (Some(2), Some(3)),
                 Some(Dist::ExactlyTimes(2).count()),
             ),
+            State::literal('a', (Some(1), None)),
             State::literal('b', (Some(4), None)),
             State::terminal(),
         ];
         let states = initial_state(&nfa, true);
-        assert_eq!(states, [(1, 1.0)].into());
+        assert_eq!(states, [(1, 1.0), (2, 1.0), (3, 0.0)].into());
 
         let counts = add_counts(&states, &HashMap::new());
-        assert_eq!(counts, [(1, 1)].into());
+        assert_eq!(counts, [(1, 1), (2, 1)].into());
         let states = step_states(states, &counts, &Kind::Literal('a'), &nfa);
         assert_eq!(states, [(1, 1.0), (2, 1.0)].into());
 
         let counts = add_counts(&states, &counts);
-        assert_eq!(counts, [(1, 2), (2, 1)].into());
+        assert_eq!(counts, [(1, 2), (2, 2)].into());
         let states = step_states(states, &counts, &Kind::Literal('a'), &nfa);
         assert_eq!(states, [(1, 1.0), (2, 1.0), (3, 1.0)].into());
 
@@ -167,21 +167,54 @@ mod test {
     }
 
     #[test]
+    fn test_step_states_exact_zero_quantifier() {
+        let nfa = vec![
+            State::anchor_start(Some(1)),
+            State::new(
+                Kind::ExactQuantifier(0),
+                (Some(2), Some(3)),
+                Some(Dist::PGeometric(1, u64::MAX, 0.5).count()),
+            ),
+            State::literal('a', (Some(1), Some(3))),
+            State::literal('b', (Some(4), None)),
+            State::terminal(),
+        ];
+        let states = initial_state(&nfa, true);
+        assert_eq!(states, [(1, 1.0), (2, 1.0), (3, 0.0)].into());
+
+        let counts = add_counts(&states, &HashMap::new());
+        assert_eq!(counts, [(1, 1), (2, 1)].into());
+
+        let states = step_states(states, &counts, &Kind::Literal('a'), &nfa);
+        assert_eq!(states, [(1, 1.0), (2, 1.0), (3, 0.5)].into());
+
+        let counts = add_counts(&states, &counts);
+        assert_eq!(counts, [(1, 2), (2, 2), (3, 1)].into());
+        let states = step_states(states, &counts, &Kind::Literal('a'), &nfa);
+        assert_eq!(states, [(1, 1.0), (2, 1.0), (3, 0.25)].into());
+
+        let counts = add_counts(&states, &counts);
+        let states = step_states(states, &counts, &Kind::Literal('b'), &nfa);
+        assert_eq!(states, [(4, 0.25)].into());
+    }
+
+    #[test]
     fn test_step_states_geo_quantifier() {
         let nfa = vec![
             State::anchor_start(Some(1)),
-            State::literal('a', (Some(2), None)),
             State::new(
                 Kind::ExactQuantifier(2),
-                (Some(1), Some(3)),
+                (Some(2), Some(3)),
                 Some(Dist::PGeometric(2, u64::MAX, 0.5).count()),
             ),
+            State::literal('a', (Some(1), None)),
             State::literal('b', (Some(4), None)),
             State::terminal(),
         ];
         let states = initial_state(&nfa, true);
         let counts = add_counts(&states, &HashMap::new());
-        assert_eq!(states, [(1, 1.0)].into());
+        assert_eq!(states, [(1, 1.0), (2, 1.0), (3, 0.0)].into());
+        assert_eq!(counts, [(1, 1), (2, 1)].into());
 
         let states = step_states(states, &counts, &Kind::Literal('a'), &nfa);
         let counts = add_counts(&states, &counts);

--- a/src/regex_state.rs
+++ b/src/regex_state.rs
@@ -91,6 +91,7 @@ pub fn evaluate_state(
                 return evaluate_state_outs(state.outs, token, p, nfa, counts, states, true);
             }
             Kind::Quantifier(_) | Kind::ExactQuantifier(_) => {
+                // NOTE: !
                 if !is_epsilon {
                     // Direct evaluation is no-op, since state used for counting only
                     return vec![];


### PR DESCRIPTION
Make `a{0}b` and `a{0~Geo}b` work.

* Add n_min and n_max to Constant distribution
* Switch NFA state order to have quantifier before quantified (large change). This makes zero "length" quantifiers possible
* Make `ast_to_frag` NFA compilation comments clearer
* Add tests