### PR TITLE
Charclass improvements

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -119,7 +119,7 @@ pub fn build_ast_from_expr(pair: Pair<Rule>) -> AstNode {
                 ),
             }
         }
-        Rule::Literal => {
+        Rule::Literal | Rule::EscapedLiteral => {
             let c = pair.as_str().chars().next().unwrap();
             AstNode {
                 length: 1,

--- a/src/distribution.rs
+++ b/src/distribution.rs
@@ -54,7 +54,7 @@ impl Dist {
             _ => 0, // required n is zero
         };
         let c = match kind {
-            Kind::Class(c) => Some(c),
+            Kind::Class(_, c) => Some(c),
             _ => None,
         };
 
@@ -294,7 +294,7 @@ impl DistLink {
                 };
 
                 match kind {
-                    Kind::Class(chars) => match chars.iter().position(|&r| r == *c) {
+                    Kind::Class(_, chars) => match chars.iter().position(|&r| r == *c) {
                         // match, evaluate for p
                         Some(idx) => match d {
                             // zipf distribution has support for x >= 1

--- a/src/distribution.rs
+++ b/src/distribution.rs
@@ -53,9 +53,9 @@ impl Dist {
             Kind::ExactQuantifier(n) => *n,
             _ => 0, // required n is zero
         };
-        let c = match kind {
-            Kind::Class(_, c) => Some(c),
-            _ => None,
+        let (is_negate, c) = match kind {
+            Kind::Class(neg, c) => (*neg, Some(c)),
+            _ => (false, None),
         };
 
         let mut pair = dist_pair.into_inner();
@@ -115,26 +115,61 @@ impl Dist {
                     None => 1,
                 };
 
-                // Sum of probability masses with given weight
-                let explicit_mass = params_named.values().sum::<f64>();
-                let implicit_mass = f64::max(0.0, 1.0 - explicit_mass);
+                let prob_mass = match is_negate {
+                    true => {
+                        // Calculate excplicit and remainder mass
+                        let explicit_mass = params_named
+                            .iter()
+                            .filter_map(|(k, v)| match *k == '.' {
+                                true => None,
+                                false => Some(*v),
+                            })
+                            .sum::<f64>();
+                        let remainder_mass = match params_named.get(&'.') {
+                            Some(v) => *v,
+                            None => f64::max(0.0, 1.0 - explicit_mass),
+                        };
 
-                // Probability mass for valid character without given weight
-                let p_implicit: f64 = f64::max(0.0, implicit_mass) / n_implicit as f64;
-                let mut prob_mass: Vec<f64> = c
-                    .expect("chars to be passed")
-                    .iter()
-                    .map(|c| *params_named.get(c).unwrap_or(&p_implicit))
-                    .collect();
+                        // Rest of proability mass is implicit
+                        let implicit_mass = f64::max(0.0, 1.0 - explicit_mass - remainder_mass);
 
-                let p_remainder: f64 = match params_named.get(&'.') {
-                    Some(v) => *v,
-                    None => f64::max(0.0, 1.0 - prob_mass.iter().sum::<f64>()),
+                        // Probability mass for valid character without given weight
+                        let p_implicit = f64::max(0.0, implicit_mass) / n_implicit as f64;
+
+                        let mut prob_mass: Vec<f64> = c
+                            .expect("chars to be passed")
+                            .iter()
+                            .map(|c| *params_named.get(c).unwrap_or(&p_implicit))
+                            .collect();
+
+                        // Insert remainder as first item to ensure prob_mass sum is not zero
+                        prob_mass.insert(0, remainder_mass);
+                        prob_mass
+                    }
+                    false => {
+                        // Calculate excplicit and remainder mass
+                        let explicit_mass = params_named.values().sum::<f64>();
+                        let implicit_mass = f64::max(0.0, 1.0 - explicit_mass);
+
+                        // Probability mass for valid character without given weight
+                        let p_implicit = f64::max(0.0, implicit_mass) / n_implicit as f64;
+                        let mut prob_mass: Vec<f64> = c
+                            .expect("chars to be passed")
+                            .iter()
+                            .map(|c| *params_named.get(c).unwrap_or(&p_implicit))
+                            .collect();
+
+                        // Probability mass for invalid character
+                        let p_remainder = match params_named.get(&'.') {
+                            Some(v) => *v,
+                            None => f64::max(0.0, 1.0 - prob_mass.iter().sum::<f64>()),
+                        };
+
+                        // Insert remainder as first item to ensure prob_mass sum is not zero
+                        prob_mass.insert(0, p_remainder);
+                        prob_mass
+                    }
                 };
-
-                // Insert remainder as first item to ensure prob_mass sum is not zero
-                prob_mass.insert(0, p_remainder);
-
                 Dist::Categorical(prob_mass)
             }
             "zipf" => {
@@ -153,15 +188,15 @@ impl Dist {
 
     /// Test helper
     pub(crate) fn evaluated(&self, x: u64, log: bool) -> (f64, f64) {
-        self.evaluate(Some(x), log)
+        self.evaluate(x, log)
     }
 
     /// Evaluate (p0, p1) for state arrows (state.outs)
-    pub fn evaluate(&self, x: Option<u64>, log: bool) -> (f64, f64) {
+    pub fn evaluate(&self, x: u64, log: bool) -> (f64, f64) {
         // Special distributions
         match self {
             Dist::Constant(n_min, n_max, p) => {
-                let n = x.unwrap();
+                let n = x;
                 return match n >= *n_min && n <= *n_max {
                     true => match log {
                         true => return (p.ln(), p.ln()),
@@ -172,7 +207,7 @@ impl Dist {
             }
             #[allow(clippy::comparison_chain)]
             Dist::ExactlyTimes(n_match) => {
-                let n = x.unwrap();
+                let n = x;
                 // does not depend on log
                 if n == *n_match {
                     return (0.0, 1.0);
@@ -188,46 +223,38 @@ impl Dist {
         // Evaluate point mass function from distribution
         let p = match self {
             Dist::PGeometric(n_min, _, c) => {
-                let n = x.unwrap();
-                if n < *n_min {
+                if x < *n_min {
                     return (1.0, 0.0);
                 }
-                let x = n - n_min + 1;
+                let x = x - n_min + 1;
                 match log {
                     true => Geometric::new(*c).unwrap().ln_pmf(x),
                     false => Geometric::new(*c).unwrap().pmf(x),
                 }
             }
             Dist::PBinomial(_, n_max, p) => {
-                let n = x.unwrap();
-                if n > *n_max {
+                if x > *n_max {
                     return (0.0, 0.0);
                 }
-                let x = n;
                 match log {
                     true => Binomial::new(*p, *n_max).unwrap().ln_pmf(x),
                     false => Binomial::new(*p, *n_max).unwrap().pmf(x),
                 }
             }
             Dist::PBernoulli(_, n_max, p) => {
-                let n = x.unwrap();
-                if n > *n_max {
+                if x > *n_max {
                     return (1.0, 0.0);
                 }
-                let x = n;
                 match log {
                     true => Bernoulli::new(*p).unwrap().ln_pmf(x),
                     false => Bernoulli::new(*p).unwrap().pmf(x),
                 }
             }
             Dist::PZipf(_, n_max, s) => {
-                let n = x.unwrap();
-                let p = zipf(n, *s, *n_max);
+                let p = zipf(x, *s, *n_max);
                 return (1. - p, p);
             }
             Dist::Categorical(prob_mass) => {
-                // Zeroth index is p_rest
-                let x = x.unwrap_or(0);
                 let p = match log {
                     true => Categorical::new(prob_mass).unwrap().ln_pmf(x),
                     false => Categorical::new(prob_mass).unwrap().pmf(x),
@@ -281,34 +308,54 @@ pub enum DistLink {
 impl DistLink {
     /// Calculates the probability mass function for the linked distribution.
     ///
-    /// Equivalent to pmf(link(token, n_visits))
-    pub fn pmf_link(&self, token: &Token, n_visits: u64, kind: &Kind, log: bool) -> (f64, f64) {
-        match self {
-            DistLink::Counted(d) => d.evaluate(Some(n_visits), log),
+    /// Equivalent to pmf(link(token, n_visits, ...))
+    pub fn pmf_link(
+        &self,
+        token: &Token,
+        x: Option<u64>,
+        kind: &Kind,
+        is_inverse: bool,
+        log: bool,
+    ) -> (f64, f64) {
+        let (p0, p1) = match self {
+            DistLink::Counted(d) => d.evaluate(x.unwrap_or(0), log),
             DistLink::Indexed(d) => {
                 let c = match token {
                     Kind::Literal(c) => c,
                     _ => {
+                        // skip non literals for now
                         return (0., 0.);
                     }
                 };
 
-                match kind {
-                    Kind::Class(_, chars) => match chars.iter().position(|&r| r == *c) {
-                        // match, evaluate for p
-                        Some(idx) => match d {
-                            // zipf distribution has support for x >= 1
-                            Dist::PZipf(_, _, _) => d.evaluate(Some(idx as u64 + 1), log),
-                            Dist::Categorical(_) => d.evaluate(Some(idx as u64 + 1), log),
-                            _ => d.evaluate(Some(idx as u64), log),
+                // TODO add to PR comments that this changed, so no longer pass Option<x> instead handle None in pmf_link
+
+                if let Some(x) = x {
+                    match d {
+                        // zipf distribution has support for x > 0
+                        Dist::PZipf(_, _, _) => d.evaluate(x + 1, log),
+                        // categorical has support for x > 0 due to p_rest
+                        Dist::Categorical(_) => d.evaluate(x + 1, log),
+                        Dist::Constant(_, _, _) => d.evaluate(0, log),
+                        _ => d.evaluate(x, log),
+                    }
+                } else {
+                    match d {
+                        Dist::Categorical(prob_mass) => {
+                            let p = prob_mass.get(0).unwrap();
+                            (1. - p, *p)
+                        }
+                        Dist::Constant(_, _, p) => match is_inverse {
+                            true => (*p, 1.),
+                            false => (*p, 1. - p),
                         },
-                        // no match, evaluate for p_rest
-                        None => d.evaluate(None, log),
-                    },
-                    _ => (0., 0.),
+                        _ => (0., 0.),
+                    }
                 }
             }
-        }
+        };
+
+        (p0, p1)
     }
 }
 

--- a/src/grammar.pest
+++ b/src/grammar.pest
@@ -19,9 +19,9 @@ Dot             =  { "." }
 
 Class           = _{ ShortClass | LongClass }
 ShortClass      =  { "\\w" | "\\s" | "\\d" }
-LongClass       =  { "[" ~ (PosixClass | CharacterClass | ShortClass) ~ Dist? ~ "]" }
+LongClass       =  { "[" ~ "^"? ~ CharacterClass ~ Dist? ~ "]" }
 PosixClass      =  { "[:digit:]" | "[:space:]" }
-CharacterClass  =  { ( Literal | Dot | ShortClass )+ }
+CharacterClass  =  { (ShortClass | PosixClass | Literal | Dot | ShortClass)+ }
 
 Quantifier      = _{ ShortQuantifier | LongQuantifier }
 ShortQuantifier =  { "+" | "?" | "*" }

--- a/src/grammar.pest
+++ b/src/grammar.pest
@@ -17,9 +17,10 @@ Escaped         = _{ "\\" ~ EscapedLiteral }
 EscapedLiteral  = @{ ASCII }
 Dot             =  { "." }
 
-Class           = _{ ShortClass | LongClass }
+Class           = _{ ShortClass | LongClassNeg | LongClass }
 ShortClass      =  { "\\w" | "\\s" | "\\d" }
-LongClass       =  { "[" ~ "^"? ~ CharacterClass ~ Dist? ~ "]" }
+LongClass       =  { "[" ~ CharacterClass ~ Dist? ~ "]" }
+LongClassNeg    =  { "[^" ~ CharacterClass ~ Dist? ~ "]" }
 PosixClass      =  { "[:digit:]" | "[:space:]" }
 CharacterClass  =  { (ShortClass | PosixClass | Literal | Dot | ShortClass)+ }
 

--- a/src/grammar.pest
+++ b/src/grammar.pest
@@ -10,9 +10,11 @@ Concat          =  { Factor ~ Factor }
 Group           = _{ "(" ~ ( Alternation | Expression ) ~ ")" }
 
 Factor          = _{ Quantified | Group | Token }
-Token           = _{ Literal | Dot | Class }
+Token           = _{ Literal | Dot | Class | Escaped }
 Quantified      =  { ( Token | Group ) ~ Quantifier }
 Literal         =  { ASCII_ALPHANUMERIC | " " | "-" }
+Escaped         = _{ "\\" ~ EscapedLiteral }
+EscapedLiteral  = @{ ASCII }
 Dot             =  { "." }
 
 Class           = _{ ShortClass | LongClass }

--- a/src/main.rs
+++ b/src/main.rs
@@ -101,6 +101,19 @@ mod test {
     }
 
     #[test]
+    fn test_literal_escape() {
+        let nfa = compile(r"^a\\db$").unwrap();
+
+        assert_eq!(match_likelihood(&nfa, &"ab".to_string(), false), None);
+        assert_eq!(match_likelihood(&nfa, &"a0b".to_string(), false), None);
+        assert_eq!(
+            match_likelihood(&nfa, &"a\\db".to_string(), false),
+            Some(1.0)
+        );
+        assert_eq!(match_likelihood(&nfa, &"a\\ddb".to_string(), false), None);
+    }
+
+    #[test]
     fn test_quantifier_zero() {
         let nfa = compile("^ab{0}$").unwrap();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -193,6 +193,15 @@ mod test {
     }
 
     #[test]
+    fn test_class_nested_geo() {
+        let nfa = compile(r"^[a\d~Geo(0.5)]$").unwrap();
+        assert_eq!(match_likelihood(&nfa, &"a".to_string(), false), Some(0.5));
+        assert_eq!(match_likelihood(&nfa, &"0".to_string(), false), Some(0.25));
+        assert_eq!(match_likelihood(&nfa, &"1".to_string(), false), Some(0.125));
+        assert_eq!(match_likelihood(&nfa, &"b".to_string(), false), None);
+    }
+
+    #[test]
     fn test_dot() {
         let nfa = compile("^a.c$").unwrap();
 

--- a/src/nfa.rs
+++ b/src/nfa.rs
@@ -187,7 +187,7 @@ fn ast_to_frag(ast: AstNode, index: usize, outs: Outs, distribution: Option<Dist
             start: index,
             outs,
         },
-        Kind::Class(_) => Frag {
+        Kind::Class(_, _) => Frag {
             // class points to outs
             // class as start
             states: vec![State::new(ast.kind, outs, distribution)],
@@ -702,7 +702,7 @@ mod test {
                 kind: Kind::Classified(
                     Box::new(AstNode {
                         length: 1,
-                        kind: Kind::Class(vec!['a', 'b', 'c']),
+                        kind: Kind::Class(true, vec!['a', 'b', 'c']),
                     }),
                     None,
                 ),
@@ -713,7 +713,7 @@ mod test {
         let expected = vec![State::from(
             AstNode {
                 length: 1,
-                kind: Kind::Class(vec!['a', 'b', 'c']),
+                kind: Kind::Class(true, vec!['a', 'b', 'c']),
             },
             (Some(1), None),
         )];
@@ -728,7 +728,7 @@ mod test {
                 kind: Kind::Classified(
                     Box::new(AstNode {
                         length: 1,
-                        kind: Kind::Class(vec!['a', 'b', 'c']),
+                        kind: Kind::Class(true, vec!['a', 'b', 'c']),
                     }),
                     Some(Dist::PGeometric(0, u64::MAX, 0.5).count()),
                 ),
@@ -737,7 +737,7 @@ mod test {
             1,
         );
         let expected = vec![State::new(
-            Kind::Class(vec!['a', 'b', 'c']),
+            Kind::Class(true, vec!['a', 'b', 'c']),
             (Some(1), None),
             Some(Dist::PGeometric(0, u64::MAX, 0.5).count()),
         )];

--- a/src/nfa.rs
+++ b/src/nfa.rs
@@ -702,7 +702,7 @@ mod test {
                 kind: Kind::Classified(
                     Box::new(AstNode {
                         length: 1,
-                        kind: Kind::Class(true, vec!['a', 'b', 'c']),
+                        kind: Kind::Class(false, vec!['a', 'b', 'c']),
                     }),
                     None,
                 ),
@@ -713,7 +713,7 @@ mod test {
         let expected = vec![State::from(
             AstNode {
                 length: 1,
-                kind: Kind::Class(true, vec!['a', 'b', 'c']),
+                kind: Kind::Class(false, vec!['a', 'b', 'c']),
             },
             (Some(1), None),
         )];
@@ -728,7 +728,7 @@ mod test {
                 kind: Kind::Classified(
                     Box::new(AstNode {
                         length: 1,
-                        kind: Kind::Class(true, vec!['a', 'b', 'c']),
+                        kind: Kind::Class(false, vec!['a', 'b', 'c']),
                     }),
                     Some(Dist::PGeometric(0, u64::MAX, 0.5).count()),
                 ),
@@ -737,7 +737,7 @@ mod test {
             1,
         );
         let expected = vec![State::new(
-            Kind::Class(true, vec!['a', 'b', 'c']),
+            Kind::Class(false, vec!['a', 'b', 'c']),
             (Some(1), None),
             Some(Dist::PGeometric(0, u64::MAX, 0.5).count()),
         )];

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -223,7 +223,7 @@ mod test {
         let expected = vec![
             AstNode {
                 length: 1,
-                kind: Kind::Class(true, vec!['a', 'b', 'c']),
+                kind: Kind::Class(false, vec!['a', 'b', 'c']),
             },
             AstNode {
                 length: 0,
@@ -242,7 +242,7 @@ mod test {
                 kind: Kind::Classified(
                     Box::new(AstNode {
                         length: 1,
-                        kind: Kind::Class(true, vec!['a', 'b', 'c']),
+                        kind: Kind::Class(false, vec!['a', 'b', 'c']),
                     }),
                     Some(Dist::PGeometric(0, u64::MAX, 0.5).index()),
                 ),
@@ -264,7 +264,7 @@ mod test {
                 kind: Kind::Classified(
                     Box::new(AstNode {
                         length: 1,
-                        kind: Kind::Class(true, vec!['a', 'b']),
+                        kind: Kind::Class(false, vec!['a', 'b']),
                     }),
                     Some(Dist::Categorical(vec![0.10000000000000009, 0.7, 0.2]).index()),
                 ),
@@ -286,7 +286,7 @@ mod test {
                 kind: Kind::Classified(
                     Box::new(AstNode {
                         length: 1,
-                        kind: Kind::Class(true, vec!['a', 'b', 'c']),
+                        kind: Kind::Class(false, vec!['a', 'b', 'c']),
                     }),
                     Some(
                         Dist::Categorical(vec![0.0, 0.7, 0.15000000000000002, 0.15000000000000002])
@@ -312,7 +312,7 @@ mod test {
                     Box::new(AstNode {
                         length: 1,
                         kind: Kind::Class(
-                            true,
+                            false,
                             vec!['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'],
                         ),
                     }),
@@ -341,9 +341,163 @@ mod test {
                 kind: Kind::Classified(
                     Box::new(AstNode {
                         length: 1,
-                        kind: Kind::Class(true, vec!['a', 'b']),
+                        kind: Kind::Class(false, vec!['a', 'b']),
                     }),
                     Some(Dist::Categorical(vec![0.1, 0.7, 0.20000000000000007]).index()),
+                ),
+            },
+            AstNode {
+                length: 0,
+                kind: Kind::Terminal,
+            },
+        ];
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_parser_exact_class_named_dot_ast_special() {
+        let result = parse("[ab~Cat(.=1.0)]").unwrap_or_default();
+        let expected = vec![
+            AstNode {
+                length: 1,
+                kind: Kind::Classified(
+                    Box::new(AstNode {
+                        length: 1,
+                        kind: Kind::Class(false, vec!['a', 'b']),
+                    }),
+                    Some(Dist::Categorical(vec![1.0, 0.0, 0.0]).index()),
+                ),
+            },
+            AstNode {
+                length: 0,
+                kind: Kind::Terminal,
+            },
+        ];
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_parser_exact_class_named_all_implicit() {
+        let result = parse("[ab~Cat]").unwrap_or_default();
+        let expected = vec![
+            AstNode {
+                length: 1,
+                kind: Kind::Classified(
+                    Box::new(AstNode {
+                        length: 1,
+                        kind: Kind::Class(false, vec!['a', 'b']),
+                    }),
+                    Some(Dist::Categorical(vec![0.0, 0.5, 0.5]).index()),
+                ),
+            },
+            AstNode {
+                length: 0,
+                kind: Kind::Terminal,
+            },
+        ];
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_parser_exact_class_named_no_implicit() {
+        let result = parse("[^ab~Cat(a=0.5,b=0.5)]").unwrap_or_default();
+        let expected = vec![
+            AstNode {
+                length: 1,
+                kind: Kind::Classified(
+                    Box::new(AstNode {
+                        length: 1,
+                        kind: Kind::Class(true, vec!['a', 'b']),
+                    }),
+                    Some(Dist::Categorical(vec![0.0, 0.5, 0.5]).index()),
+                ),
+            },
+            AstNode {
+                length: 0,
+                kind: Kind::Terminal,
+            },
+        ];
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_parser_exact_class_const() {
+        let result = parse("[ab~Const]").unwrap_or_default();
+        let expected = vec![
+            AstNode {
+                length: 1,
+                kind: Kind::Classified(
+                    Box::new(AstNode {
+                        length: 1,
+                        kind: Kind::Class(false, vec!['a', 'b']),
+                    }),
+                    Some(Dist::Constant(0, 0, 1.0).index()),
+                ),
+            },
+            AstNode {
+                length: 0,
+                kind: Kind::Terminal,
+            },
+        ];
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_parser_exact_class_neg_all_implicit() {
+        let result = parse("[^ab~Cat]").unwrap_or_default();
+        let expected = vec![
+            AstNode {
+                length: 1,
+                kind: Kind::Classified(
+                    Box::new(AstNode {
+                        length: 1,
+                        kind: Kind::Class(true, vec!['a', 'b']),
+                    }),
+                    Some(Dist::Categorical(vec![1.0, 0.0, 0.0]).index()),
+                ),
+            },
+            AstNode {
+                length: 0,
+                kind: Kind::Terminal,
+            },
+        ];
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_parser_exact_class_neg() {
+        let result = parse("[^ab~Cat(a=0.1)]").unwrap_or_default();
+        let expected = vec![
+            AstNode {
+                length: 1,
+                kind: Kind::Classified(
+                    Box::new(AstNode {
+                        length: 1,
+                        kind: Kind::Class(true, vec!['a', 'b']),
+                    }),
+                    Some(Dist::Categorical(vec![0.9, 0.1, 0.0]).index()),
+                ),
+            },
+            AstNode {
+                length: 0,
+                kind: Kind::Terminal,
+            },
+        ];
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_parser_exact_class_neg_dot() {
+        let result = parse("[^ab~Cat(a=0.3,.=0.1)]").unwrap_or_default();
+        let expected = vec![
+            AstNode {
+                length: 1,
+                kind: Kind::Classified(
+                    Box::new(AstNode {
+                        length: 1,
+                        kind: Kind::Class(true, vec!['a', 'b']),
+                    }),
+                    Some(Dist::Categorical(vec![0.1, 0.3, 0.6]).index()),
                 ),
             },
             AstNode {
@@ -364,7 +518,7 @@ mod test {
                     Box::new(AstNode {
                         length: 1,
                         kind: Kind::Class(
-                            true,
+                            false,
                             vec!['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'],
                         ),
                     }),
@@ -409,7 +563,7 @@ mod test {
                     Box::new(AstNode {
                         length: 1,
                         kind: Kind::Class(
-                            true,
+                            false,
                             vec!['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'],
                         ),
                     }),
@@ -441,7 +595,10 @@ mod test {
         let expected = vec![
             AstNode {
                 length: 1,
-                kind: Kind::Class(true, vec!['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']),
+                kind: Kind::Class(
+                    false,
+                    vec!['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'],
+                ),
             },
             AstNode {
                 length: 0,
@@ -457,7 +614,10 @@ mod test {
         let expected = vec![
             AstNode {
                 length: 1,
-                kind: Kind::Class(true, vec!['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']),
+                kind: Kind::Class(
+                    false,
+                    vec!['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'],
+                ),
             },
             AstNode {
                 length: 0,
@@ -570,6 +730,7 @@ mod test {
     #[test]
     fn test_parser_exact_class() {
         assert_eq!(ast_as_str(parse("[ab]").unwrap()), "[ab]");
+        assert_eq!(ast_as_str(parse("[^ab]").unwrap()), "[^ab]");
     }
 
     #[test]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -223,7 +223,7 @@ mod test {
         let expected = vec![
             AstNode {
                 length: 1,
-                kind: Kind::Class(vec!['a', 'b', 'c']),
+                kind: Kind::Class(true, vec!['a', 'b', 'c']),
             },
             AstNode {
                 length: 0,
@@ -242,7 +242,7 @@ mod test {
                 kind: Kind::Classified(
                     Box::new(AstNode {
                         length: 1,
-                        kind: Kind::Class(vec!['a', 'b', 'c']),
+                        kind: Kind::Class(true, vec!['a', 'b', 'c']),
                     }),
                     Some(Dist::PGeometric(0, u64::MAX, 0.5).index()),
                 ),
@@ -264,7 +264,7 @@ mod test {
                 kind: Kind::Classified(
                     Box::new(AstNode {
                         length: 1,
-                        kind: Kind::Class(vec!['a', 'b']),
+                        kind: Kind::Class(true, vec!['a', 'b']),
                     }),
                     Some(Dist::Categorical(vec![0.10000000000000009, 0.7, 0.2]).index()),
                 ),
@@ -286,7 +286,7 @@ mod test {
                 kind: Kind::Classified(
                     Box::new(AstNode {
                         length: 1,
-                        kind: Kind::Class(vec!['a', 'b', 'c']),
+                        kind: Kind::Class(true, vec!['a', 'b', 'c']),
                     }),
                     Some(
                         Dist::Categorical(vec![0.0, 0.7, 0.15000000000000002, 0.15000000000000002])
@@ -311,7 +311,10 @@ mod test {
                 kind: Kind::Classified(
                     Box::new(AstNode {
                         length: 1,
-                        kind: Kind::Class(vec!['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']),
+                        kind: Kind::Class(
+                            true,
+                            vec!['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'],
+                        ),
                     }),
                     Some(
                         Dist::Categorical(vec![
@@ -338,7 +341,7 @@ mod test {
                 kind: Kind::Classified(
                     Box::new(AstNode {
                         length: 1,
-                        kind: Kind::Class(vec!['a', 'b']),
+                        kind: Kind::Class(true, vec!['a', 'b']),
                     }),
                     Some(Dist::Categorical(vec![0.1, 0.7, 0.20000000000000007]).index()),
                 ),
@@ -360,7 +363,10 @@ mod test {
                 kind: Kind::Classified(
                     Box::new(AstNode {
                         length: 1,
-                        kind: Kind::Class(vec!['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']),
+                        kind: Kind::Class(
+                            true,
+                            vec!['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'],
+                        ),
                     }),
                     Some(
                         Dist::Categorical(vec![
@@ -402,7 +408,10 @@ mod test {
                 kind: Kind::Classified(
                     Box::new(AstNode {
                         length: 1,
-                        kind: Kind::Class(vec!['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']),
+                        kind: Kind::Class(
+                            true,
+                            vec!['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'],
+                        ),
                     }),
                     Some(
                         Dist::Categorical(vec![
@@ -432,7 +441,7 @@ mod test {
         let expected = vec![
             AstNode {
                 length: 1,
-                kind: Kind::Class(vec!['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']),
+                kind: Kind::Class(true, vec!['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']),
             },
             AstNode {
                 length: 0,
@@ -448,7 +457,7 @@ mod test {
         let expected = vec![
             AstNode {
                 length: 1,
-                kind: Kind::Class(vec!['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']),
+                kind: Kind::Class(true, vec!['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']),
             },
             AstNode {
                 length: 0,

--- a/src/regex_state.rs
+++ b/src/regex_state.rs
@@ -133,7 +133,7 @@ pub fn evaluate_state(
                     }
                 }
             }
-            Kind::Class(ref match_c) => {
+            Kind::Class(neg, ref match_c) => {
                 if is_epsilon {
                     return vec![Transition(Some(idx), p)];
                 }
@@ -340,7 +340,7 @@ mod test {
         let nfa = vec![
             State::anchor_start(Some(1)),
             State::new(
-                Kind::Class(vec!['a', 'b', 'c']),
+                Kind::Class(true, vec!['a', 'b', 'c']),
                 (Some(2), None),
                 Some(DistLink::Indexed(Dist::PGeometric(0, u64::MAX, 0.5))),
             ),


### PR DESCRIPTION
Lots of changes to charclasses. Changes over a long timeframe (jan-may 23), and some design decisions are not trivial.

* Add negation `a[^bc]` along with distriibutions.
* Move negation and zero-match cases to `pmf_link`.
* Escaped literals `\.`.

Examples:
* categorical symmetry
  * `^[^ab~Cat]$` matches `a,b,d` with `None, None, Some(1.0)`
  * `^[ab~Cat]$ ` matches `a,b,d` with `Some(0.5), Some(0.5), None`
  * categorical distribution is mostly proper (sums to 1)
* const symmetry
  *  `^[abc~Const]$ ` matches `a,b,c,d` with `Some(1.0), Some(1.0), Some(1.0), None`. 
  * `^[^abc~Const]$` matches `a,b,c,d` with `Some(1.0), Some(1.0), Some(1.0), Some(1.0)`
  * const distribution is improper